### PR TITLE
설문조사와 설문 받을 항목, 항목 입력 형태 Entity 작성

### DIFF
--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/Item.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/Item.kt
@@ -1,0 +1,21 @@
+package com.onboarding.form.domain
+
+import jakarta.persistence.*
+
+@Entity
+class Item(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+    @ManyToOne
+    @JoinColumn(name = "survey_id")
+    val survey: Survey,
+    val title: String,
+    val description: String,
+    @Enumerated(EnumType.STRING)
+    val type: ItemType,
+    val isRequired: Boolean,
+    @ElementCollection
+    @CollectionTable
+    val options: MutableList<String> = mutableListOf()
+)

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/ItemType.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/ItemType.kt
@@ -1,0 +1,8 @@
+package com.onboarding.form.domain
+
+enum class ItemType {
+    SHORT, // 단답형
+    LONG, // 장문형
+    SINGLE_SELECT,  // 단일 선택 리스트
+    MULTI_SELECT, // 다중 선택 리스트
+}

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/Survey.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/Survey.kt
@@ -1,0 +1,18 @@
+package com.onboarding.form.domain
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
+
+
+@Entity
+class Survey (
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+    val title: String,
+    val description: String,
+    @OneToMany(mappedBy = "survey")
+    val item: List<Item>
+)


### PR DESCRIPTION
## Goal

요구사항을 만족하는 Entity 를 생성합니다.


## Changes

설문조사와 설문 받을 항목, 항목 입력 형태 Entity 를 생성하였습니다.

## Description

- 설문조사는 다음 값을 가집니다
  - 설문조사 이름
  - 설문조사 설명
  - 설문 받을 항목
- 설문 받을 항목은 다음 값을 가집니다.
  - 항목 이름
  - 항목 설명
  - 항목 입력 형태
  - 항목 필수 여부
  - 선택 리스트(단일, 다중) -> 항목 입력 형태에 따라

## Additional Context (Optional)
일반적으로 이런 기능을 개발해야할 때에는 상황에 맞춰서 하나의 클래스에 데이터를 매핑하고 관리하지만
Disciriminator 를 통해 표현하면 설문 받을 항목에 다형성을 이용하여 작성할 수 있어 보입니다.
JPA를 잘 모른다면 사용하기 어려운 감이 없지 않아 있으나 태양님은 이런 상황에서는 어떤 방법을 선택하시는지 궁금합니다.


