### PR TITLE
DB 설계 및 엔티티 클래스 정의

### DIFF
--- a/project/sangkyeong-onboarding/bootstrap/build.gradle.kts
+++ b/project/sangkyeong-onboarding/bootstrap/build.gradle.kts
@@ -1,3 +1,6 @@
 dependencies {
     implementation(project(":presentation"))
+    implementation(project(":application"))
+    implementation(project(":infra"))
+    implementation(project(":domain"))
 }

--- a/project/sangkyeong-onboarding/build.gradle.kts
+++ b/project/sangkyeong-onboarding/build.gradle.kts
@@ -19,6 +19,7 @@ subprojects {
     apply(plugin = "org.springframework.boot")
     apply(plugin = "org.jetbrains.kotlin.plugin.spring")
     apply(plugin = "kotlin")
+    apply(plugin = "org.jetbrains.kotlin.plugin.jpa")
 
     group = "org.innercircle"
     version = "0.0.1-SNAPSHOT"

--- a/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/response/AnswerEntity.kt
+++ b/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/response/AnswerEntity.kt
@@ -1,0 +1,28 @@
+package org.survey.infra.persistence.entity.response
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "answer")
+class AnswerEntity(
+    surveyResponseId: Long,
+    surveyItemId: Long,
+    value: String? = null,
+    itemOptionId: Long? = null,
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0
+
+    var surveyResponseId: Long = surveyResponseId
+        protected set
+
+    var surveyItemId: Long = surveyItemId
+        protected set
+
+    var value: String? = value
+        protected set
+
+    var itemOptionId: Long? = itemOptionId
+        protected set
+}

--- a/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/response/AnswerOptionEntity.kt
+++ b/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/response/AnswerOptionEntity.kt
@@ -5,14 +5,14 @@ import jakarta.persistence.*
 @Entity
 @Table(name = "answer_option")
 class AnswerOptionEntity(
-    responseAnswerId: Long,
+    answerId: Long,
     itemOptionId: Long,
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0
 
-    var responseAnswerId: Long = responseAnswerId
+    var answerId: Long = answerId
         protected set
 
     var itemOptionId: Long = itemOptionId

--- a/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/response/AnswerOptionEntity.kt
+++ b/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/response/AnswerOptionEntity.kt
@@ -1,0 +1,20 @@
+package org.survey.infra.persistence.entity.response
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "answer_option")
+class AnswerOptionEntity(
+    responseAnswerId: Long,
+    itemOptionId: Long,
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0
+
+    var responseAnswerId: Long = responseAnswerId
+        protected set
+
+    var itemOptionId: Long = itemOptionId
+        protected set
+}

--- a/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/response/SurveyResponseEntity.kt
+++ b/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/response/SurveyResponseEntity.kt
@@ -4,7 +4,7 @@ import jakarta.persistence.*
 import java.time.LocalDateTime
 
 @Entity
-@Table(name = "survey-response")
+@Table(name = "survey_response")
 class SurveyResponseEntity(
     surveyId: Long,
 ) {

--- a/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/response/SurveyResponseEntity.kt
+++ b/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/response/SurveyResponseEntity.kt
@@ -1,0 +1,21 @@
+package org.survey.infra.persistence.entity.response
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "survey-response")
+class SurveyResponseEntity(
+    surveyId: Long,
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0
+
+    var surveyId: Long = surveyId
+        protected set
+
+    @Column(nullable = false, updatable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
+        protected set
+}

--- a/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/survey/ItemOptionEntity.kt
+++ b/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/survey/ItemOptionEntity.kt
@@ -1,0 +1,20 @@
+package org.survey.infra.persistence.entity.survey
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "item_option")
+class ItemOptionEntity(
+    surveyItemId: Long,
+    value: String,
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0
+
+    var surveyItemId: Long = surveyItemId
+        protected set
+
+    var value: String = value
+        protected set
+}

--- a/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/survey/SurveyEntity.kt
+++ b/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/survey/SurveyEntity.kt
@@ -1,0 +1,29 @@
+package org.survey.infra.persistence.entity.survey
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "survey")
+class SurveyEntity(
+    title: String,
+    description: String,
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0
+
+    var title: String = title
+        protected set
+
+    var description: String = description
+        protected set
+
+    @Column(nullable = false, updatable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
+        protected set
+
+    @Column(nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+        protected set
+}

--- a/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/survey/SurveyItemEntity.kt
+++ b/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/survey/SurveyItemEntity.kt
@@ -3,7 +3,7 @@ package org.survey.infra.persistence.entity.survey
 import jakarta.persistence.*
 
 @Entity
-@Table(name = "survey-item")
+@Table(name = "survey_item")
 class SurveyItemEntity(
     surveyId: Long,
     title: String,

--- a/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/survey/SurveyItemEntity.kt
+++ b/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/survey/SurveyItemEntity.kt
@@ -29,4 +29,7 @@ class SurveyItemEntity(
 
     var isRequired: Boolean = isRequired
         protected set
+
+    var isDeleted: Boolean = false
+        protected set
 }

--- a/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/survey/SurveyItemEntity.kt
+++ b/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/survey/SurveyItemEntity.kt
@@ -1,0 +1,32 @@
+package org.survey.infra.persistence.entity.survey
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "survey-item")
+class SurveyItemEntity(
+    surveyId: Long,
+    title: String,
+    description: String,
+    inputType: String,
+    isRequired: Boolean,
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id = 0
+
+    var surveyId: Long = surveyId
+        protected set
+
+    var title: String = title
+        protected set
+
+    var description: String = description
+        protected set
+
+    var inputType: String = inputType
+        protected set
+
+    var isRequired: Boolean = isRequired
+        protected set
+}

--- a/project/sangkyeong-onboarding/infra/src/main/resources/application-db.yml
+++ b/project/sangkyeong-onboarding/infra/src/main/resources/application-db.yml
@@ -1,1 +1,17 @@
-# h2 세팅 추가
+spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/test
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+  sql:
+    init:
+      mode: always

--- a/project/sangkyeong-onboarding/infra/src/main/resources/data.sql
+++ b/project/sangkyeong-onboarding/infra/src/main/resources/data.sql
@@ -1,0 +1,119 @@
+
+-- 테스트 데이터 삽입
+
+-- 설문조사 1: 고객 만족도 조사
+INSERT INTO survey (id, title, description, created_at, updated_at)
+VALUES (1, '고객 만족도 조사', '저희 서비스에 대한 만족도를 평가해주세요.', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+-- 설문조사 1의 문항들
+-- 1. 단답형 질문
+INSERT INTO survey_item (id, survey_id, title, description, input_type, is_required)
+VALUES (1, 1, '이름을 입력해주세요.', NULL, 'SHORT_TEXT', true);
+
+-- 2. 장문형 질문
+INSERT INTO survey_item (id, survey_id, title, description, input_type, is_required)
+VALUES (2, 1, '저희 서비스에 대한 의견을 자유롭게 작성해주세요.', '개선사항이나 불편한 점을 알려주세요.', 'LONG_TEXT', false);
+
+-- 3. 단일 선택형 질문
+INSERT INTO survey_item (id, survey_id, title, description, input_type, is_required)
+VALUES (3, 1, '전반적인 서비스 만족도는 어떠신가요?', NULL, 'SINGLE_CHOICE', true);
+
+-- 단일 선택형 질문의 선택지
+INSERT INTO item_option (id, survey_item_id, value) VALUES (1, 3, '매우 만족');
+INSERT INTO item_option (id, survey_item_id, value) VALUES (2, 3, '만족');
+INSERT INTO item_option (id, survey_item_id, value) VALUES (3, 3, '보통');
+INSERT INTO item_option (id, survey_item_id, value) VALUES (4, 3, '불만족');
+INSERT INTO item_option (id, survey_item_id, value) VALUES (5, 3, '매우 불만족');
+
+-- 4. 다중 선택형 질문
+INSERT INTO survey_item (id, survey_id, title, description, input_type, is_required)
+VALUES (4, 1, '가장 자주 이용하시는 기능은 무엇인가요? (복수 선택 가능)', NULL, 'MULTIPLE_CHOICE', false);
+
+-- 다중 선택형 질문의 선택지
+INSERT INTO item_option (id, survey_item_id, value) VALUES (6, 4, '주문 기능');
+INSERT INTO item_option (id, survey_item_id, value) VALUES (7, 4, '배송 조회');
+INSERT INTO item_option (id, survey_item_id, value) VALUES (8, 4, '고객 서비스');
+INSERT INTO item_option (id, survey_item_id, value) VALUES (9, 4, '리뷰 작성');
+INSERT INTO item_option (id, survey_item_id, value) VALUES (10, 4, '포인트 적립');
+
+-- 설문조사 2: 이벤트 참여 신청서
+INSERT INTO survey (id, title, description, created_at, updated_at)
+VALUES (2, '2025년 봄 신제품 출시 이벤트 신청', '신제품 체험단 모집을 위한 신청서입니다.', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+-- 설문조사 2의 문항들
+-- 1. 단답형 질문
+INSERT INTO survey_item (id, survey_id, title, description, input_type, is_required)
+VALUES (5, 2, '이름', NULL, 'SHORT_TEXT', true);
+
+-- 2. 단답형 질문
+INSERT INTO survey_item (id, survey_id, title, description, input_type, is_required)
+VALUES (6, 2, '연락처', '연락 가능한 전화번호를 입력해주세요.', 'SHORT_TEXT', true);
+
+-- 3. 단답형 질문
+INSERT INTO survey_item (id, survey_id, title, description, input_type, is_required)
+VALUES (7, 2, '이메일', NULL, 'SHORT_TEXT', true);
+
+-- 4. 장문형 질문
+INSERT INTO survey_item (id, survey_id, title, description, input_type, is_required)
+VALUES (8, 2, '지원 동기', '신제품 체험단에 지원하시는 이유를 작성해주세요.', 'LONG_TEXT', true);
+
+-- 5. 단일 선택형 질문
+INSERT INTO survey_item (id, survey_id, title, description, input_type, is_required)
+VALUES (9, 2, '체험을 원하는 제품', NULL, 'SINGLE_CHOICE', true);
+
+-- 단일 선택형 질문의 선택지
+INSERT INTO item_option (id, survey_item_id, value) VALUES (11, 9, '스마트 워치');
+INSERT INTO item_option (id, survey_item_id, value) VALUES (12, 9, '무선 이어폰');
+INSERT INTO item_option (id, survey_item_id, value) VALUES (13, 9, '블루투스 스피커');
+
+-- 설문조사 1에 대한 응답 예시
+-- 응답 1
+INSERT INTO survey_response (id, survey_id, created_at)
+VALUES (1, 1, CURRENT_TIMESTAMP);
+
+-- 응답 1의 답변들
+INSERT INTO answer (id, survey_response_id, survey_item_id, value)
+VALUES (1, 1, 1, '김철수');
+
+INSERT INTO answer (id, survey_response_id, survey_item_id, value)
+VALUES (2, 1, 2, '전반적으로 만족하지만 배송이 조금 느린 것 같습니다. 배송 속도가 개선되면 좋겠습니다.');
+
+INSERT INTO answer (id, survey_response_id, survey_item_id, item_option_id)
+VALUES (3, 1, 3, 2);
+
+-- 다중 선택형 질문에 대한 답변
+INSERT INTO answer (id, survey_response_id, survey_item_id)
+VALUES (4, 1, 4);
+
+INSERT INTO answer_option (id, answer_id, item_option_id)
+VALUES (1, 4, 6);
+
+INSERT INTO answer_option (id, answer_id, item_option_id)
+VALUES (2, 4, 7);
+
+-- 응답 2
+INSERT INTO survey_response (id, survey_id, created_at)
+VALUES (2, 1, CURRENT_TIMESTAMP);
+
+-- 응답 2의 답변들
+INSERT INTO answer (id, survey_response_id, survey_item_id, value)
+VALUES (5, 2, 1, '이영희');
+
+INSERT INTO answer (id, survey_response_id, survey_item_id, value)
+VALUES (6, 2, 2, '상품 품질이 좋고 고객 서비스도 친절해요. 계속 이용할 예정입니다.');
+
+INSERT INTO answer (id, survey_response_id, survey_item_id, item_option_id)
+VALUES (7, 2, 3, 1);
+
+-- 다중 선택형 질문에 대한 답변
+INSERT INTO answer (id, survey_response_id, survey_item_id)
+VALUES (8, 2, 4);
+
+INSERT INTO answer_option (id, answer_id, item_option_id)
+VALUES (3, 8, 8);
+
+INSERT INTO answer_option (id, answer_id, item_option_id)
+VALUES (4, 8, 9);
+
+INSERT INTO answer_option (id, answer_id, item_option_id)
+VALUES (5, 8, 10);

--- a/project/sangkyeong-onboarding/infra/src/main/resources/schema.sql
+++ b/project/sangkyeong-onboarding/infra/src/main/resources/schema.sql
@@ -1,0 +1,58 @@
+DROP TABLE IF EXISTS answer_option;
+DROP TABLE IF EXISTS answer;
+DROP TABLE IF EXISTS survey_response;
+DROP TABLE IF EXISTS item_option;
+DROP TABLE IF EXISTS survey_item;
+DROP TABLE IF EXISTS survey;
+
+CREATE TABLE survey (
+                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                        title VARCHAR(255) NOT NULL,
+                        description VARCHAR(255),
+                        created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE survey_item (
+                             id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                             survey_id BIGINT NOT NULL,
+                             title VARCHAR(255) NOT NULL,
+                             description VARCHAR(255),
+                             input_type VARCHAR(20) NOT NULL,
+                             is_required BOOLEAN NOT NULL DEFAULT FALSE,
+                             is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+                             FOREIGN KEY (survey_id) REFERENCES survey(id)
+);
+
+CREATE TABLE item_option (
+                             id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                             survey_item_id BIGINT NOT NULL,
+                             value VARCHAR(255) NOT NULL,
+                             FOREIGN KEY (survey_item_id) REFERENCES survey_item(id)
+);
+
+CREATE TABLE survey_response (
+                                 id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                 survey_id BIGINT NOT NULL,
+                                 created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                 FOREIGN KEY (survey_id) REFERENCES survey(id)
+);
+
+CREATE TABLE answer (
+                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                        survey_response_id BIGINT NOT NULL,
+                        survey_item_id BIGINT NOT NULL,
+                        item_option_id BIGINT,
+                        value VARCHAR(255),
+                        FOREIGN KEY (survey_response_id) REFERENCES survey_response(id),
+                        FOREIGN KEY (survey_item_id) REFERENCES survey_item(id),
+                        FOREIGN KEY (item_option_id) REFERENCES item_option(id)
+);
+
+CREATE TABLE answer_option (
+                               id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                               answer_id BIGINT NOT NULL,
+                               item_option_id BIGINT NOT NULL,
+                               FOREIGN KEY (answer_id) REFERENCES answer(id),
+                               FOREIGN KEY (item_option_id) REFERENCES item_option(id)
+);


### PR DESCRIPTION
## Goal

<!-- Describe the goal of this PR -->
DB 설계 및 엔티티 클래스를 정의합니다.

## Changes

<!-- Describe the changes made in this PR -->
설문조사 도메인을 추가합니다.
- Survey, SurveyItem, ItemOption

설문조사 응답 도메인을 추가합니다.
- SurveyResponse, Answer, AnswerOption


## Description

<!-- Describe the changes made in this PR -->
answerOption은 다중 답변 선택을 위한 옵션이며, item_option_id, value가 모두 null일 때 사용한다.
item_option_id가 null이고 value가 null이 아니면 단문, 장문형이다.
item_option_id가 null이 아니고 value가 null이면 단일 선택형이다.

## Screenshots/Videos (Optional)

<!-- Add screenshots if applicable -->
<img width="1088" alt="image" src="https://github.com/user-attachments/assets/573d03a1-547a-4cdf-8fe8-0b8658133637" />


## Question
1. 이전에 plugin.jpa에서 세가지 애노테이션에 대해 자동으로 포함되어 컴파일이 된다는 것은 리뷰를 달아주셔서 확인을 했었는데요~ 요렇게 엔티티를 정의해보니 각 프로퍼티 protected set에서 final 클래스이니 open 클래스로 만들어라 라는 경고가 나오는데 런타임에서 에러가 나오는건 확인을 못했어서 혹시 문제가 없을지 궁금하네요.

<img width="582" alt="image" src="https://github.com/user-attachments/assets/d116c13d-9d4c-4bf9-bebf-0dd79b6f1cc9" />