### PR TITLE
[Feat] 설문조사 생성 API

### DIFF
--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/common/ApiResponse.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/common/ApiResponse.java
@@ -1,0 +1,16 @@
+package me.dhlee.donghyeononboarding.common;
+
+public record ApiResponse<T>(
+    int httpCode,
+    String message,
+    T data
+) {
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(200, null, data);
+    }
+
+    public static <T> ApiResponse<T> badRequest(String message) {
+        return new ApiResponse<>(400, message, null);
+    }
+}

--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/common/BaseEntity.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/common/BaseEntity.java
@@ -1,0 +1,33 @@
+package me.dhlee.donghyeononboarding.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+}

--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/config/JpaConfig.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package me.dhlee.donghyeononboarding.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+}

--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/domain/ItemType.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/domain/ItemType.java
@@ -1,0 +1,21 @@
+package me.dhlee.donghyeononboarding.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ItemType {
+
+    SHORT_TEXT("단답형"),
+    LONG_TEXT("장문형"),
+    SINGLE_SELECT("단일선택 리스트"),
+    MULTI_SELECT("다중선택 리스트"),
+    ;
+
+    private final String description;
+
+    public boolean isSelectable() {
+        return this == SINGLE_SELECT || this == MULTI_SELECT;
+    }
+}

--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/domain/Survey.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/domain/Survey.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import me.dhlee.donghyeononboarding.common.BaseEntity;
+import me.dhlee.donghyeononboarding.exception.AppException;
+import me.dhlee.donghyeononboarding.exception.ErrorCode;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -34,5 +36,16 @@ public class Survey extends BaseEntity {
     private Survey(String title, String description) {
         this.title = title;
         this.description = description;
+    }
+
+    public void addItem(SurveyItem item) {
+        if (isFull()) {
+            throw new AppException(ErrorCode.SURVEY_ITEM_SIZE_OVERFLOW);
+        }
+        this.items.add(item);
+    }
+
+    private boolean isFull() {
+        return items.size() >= 10;
     }
 }

--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/domain/Survey.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/domain/Survey.java
@@ -1,0 +1,38 @@
+package me.dhlee.donghyeononboarding.domain;
+
+import org.hibernate.annotations.SQLRestriction;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.dhlee.donghyeononboarding.common.BaseEntity;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at is null")
+@Table(name = "Surveys")
+@Entity
+public class Survey extends BaseEntity {
+
+    @Column(length = 100, nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String description;
+
+    @OneToMany(mappedBy = "survey", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<SurveyItem> items = new HashSet<>();
+
+    @Builder
+    private Survey(String title, String description) {
+        this.title = title;
+        this.description = description;
+    }
+}

--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/domain/SurveyItem.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/domain/SurveyItem.java
@@ -1,0 +1,72 @@
+package me.dhlee.donghyeononboarding.domain;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import org.hibernate.annotations.SQLRestriction;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.dhlee.donghyeononboarding.common.BaseEntity;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at is null")
+@Table(name = "survey_items")
+@Entity
+public class SurveyItem extends BaseEntity {
+
+    @JoinColumn(name = "survey_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Survey survey;
+
+    @OneToMany(mappedBy = "surveyItem", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<SurveyItemOption> options = new HashSet<>();
+
+    @Column(length = 100, nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ItemType itemType;
+
+    @Column(nullable = false)
+    private boolean isRequired = false;
+
+    private int displayOrder;
+
+    @Builder
+    public SurveyItem(
+        String title,
+        String description,
+        ItemType itemType,
+        boolean isRequired,
+        int displayOrder,
+        Survey survey
+    ) {
+        this.title = title;
+        this.description = description;
+        this.itemType = itemType;
+        this.isRequired = isRequired;
+        this.displayOrder = displayOrder;
+        this.survey = survey;
+    }
+}

--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/domain/SurveyItem.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/domain/SurveyItem.java
@@ -23,6 +23,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import me.dhlee.donghyeononboarding.common.BaseEntity;
+import me.dhlee.donghyeononboarding.exception.AppException;
+import me.dhlee.donghyeononboarding.exception.ErrorCode;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -68,5 +70,16 @@ public class SurveyItem extends BaseEntity {
         this.isRequired = isRequired;
         this.displayOrder = displayOrder;
         this.survey = survey;
+    }
+
+    public void addOption(SurveyItemOption option) {
+        if (isFull()) {
+            throw new AppException(ErrorCode.SURVEY_ITEM_OPTION_SIZE_OVERFLOW);
+        }
+        this.options.add(option);
+    }
+
+    private boolean isFull() {
+        return this.options.size() > 10;
     }
 }

--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/domain/SurveyItemOption.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/domain/SurveyItemOption.java
@@ -1,0 +1,34 @@
+package me.dhlee.donghyeononboarding.domain;
+
+import org.hibernate.annotations.SQLRestriction;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.dhlee.donghyeononboarding.common.BaseEntity;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at is null")
+@Table(name = "survey_item_options")
+@Entity
+public class SurveyItemOption extends BaseEntity {
+
+    @JoinColumn(name = "survey_item_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private SurveyItem surveyItem;
+
+    @Column(length = 100, nullable = false)
+    private String title;
+
+    private int displayOrder;
+
+    @Builder
+    private SurveyItemOption(String title, int displayOrder, SurveyItem surveyItem) {
+        this.title = title;
+        this.displayOrder = displayOrder;
+        this.surveyItem = surveyItem;
+    }
+}

--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/dto/request/SurveyCreateRequest.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/dto/request/SurveyCreateRequest.java
@@ -1,0 +1,36 @@
+package me.dhlee.donghyeononboarding.dto.request;
+
+import java.util.List;
+
+import org.springframework.util.ObjectUtils;
+
+import me.dhlee.donghyeononboarding.domain.Survey;
+import me.dhlee.donghyeononboarding.exception.AppException;
+import me.dhlee.donghyeononboarding.exception.ErrorCode;
+
+public record SurveyCreateRequest(
+    String title,
+    String description,
+    List<SurveyItemCreateRequest> items
+) {
+    public SurveyCreateRequest {
+        if (ObjectUtils.isEmpty(title)) {
+            throw new AppException(ErrorCode.SURVEY_TITLE_IS_EMPTY);
+        }
+        if (ObjectUtils.isEmpty(description)) {
+            throw new AppException(ErrorCode.SURVEY_DESCRIPTION_IS_EMPTY);
+        }
+        if (ObjectUtils.isEmpty(items)) {
+            throw new AppException(ErrorCode.SURVEY_ITEM_IS_EMPTY);
+        }
+        if (items.size() >= 10) {
+            throw new AppException(ErrorCode.SURVEY_ITEM_SIZE_OVERFLOW);
+        }
+    }
+    public Survey toEntity() {
+        return Survey.builder()
+            .title(title)
+            .description(description)
+            .build();
+    }
+}

--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/dto/request/SurveyItemCreateRequest.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/dto/request/SurveyItemCreateRequest.java
@@ -1,0 +1,57 @@
+package me.dhlee.donghyeononboarding.dto.request;
+
+import java.util.List;
+
+import org.springframework.util.ObjectUtils;
+
+import me.dhlee.donghyeononboarding.domain.ItemType;
+import me.dhlee.donghyeononboarding.domain.Survey;
+import me.dhlee.donghyeononboarding.domain.SurveyItem;
+import me.dhlee.donghyeononboarding.exception.AppException;
+import me.dhlee.donghyeononboarding.exception.ErrorCode;
+
+public record SurveyItemCreateRequest(
+    String title,
+    String description,
+    ItemType itemType,
+    boolean isRequired,
+    int displayOrder,
+    List<SurveyItemOptionCreateRequest> options
+) {
+    public SurveyItemCreateRequest {
+        if (ObjectUtils.isEmpty(title)) {
+            throw new AppException(ErrorCode.SURVEY_ITEM_TITLE_IS_EMPTY);
+        }
+        if (ObjectUtils.isEmpty(description)) {
+            throw new AppException(ErrorCode.SURVEY_ITEM_DESCRIPTION_IS_EMPTY);
+        }
+        if (itemType == null) {
+            throw new AppException(ErrorCode.SURVEY_ITEM_TYPE_IS_EMPTY);
+        }
+        if (displayOrder < 0) {
+            throw new AppException(ErrorCode.DISPLAY_ORDER_IS_NEGATIVE);
+        }
+        if (itemType.isSelectable()) {
+            if (ObjectUtils.isEmpty(options)) {
+                throw new AppException(ErrorCode.SURVEY_ITEM_OPTION_IS_EMPTY);
+            }
+            if (options.size() >= 10) {
+                throw new AppException(ErrorCode.SURVEY_ITEM_OPTION_SIZE_OVERFLOW);
+            }
+        } else {
+            if (!ObjectUtils.isEmpty(options)) {
+                throw new AppException(ErrorCode.NOT_SELECTABLE_ITEM_TYPE_SHOULD_HAVE_NOT_OPTIONS);
+            }
+        }
+    }
+    public SurveyItem toEntity(Survey survey) {
+        return SurveyItem.builder()
+            .title(title)
+            .description(description)
+            .itemType(itemType)
+            .isRequired(isRequired)
+            .displayOrder(displayOrder)
+            .survey(survey)
+            .build();
+    }
+}

--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/dto/request/SurveyItemOptionCreateRequest.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/dto/request/SurveyItemOptionCreateRequest.java
@@ -1,0 +1,29 @@
+package me.dhlee.donghyeononboarding.dto.request;
+
+import org.springframework.util.ObjectUtils;
+
+import me.dhlee.donghyeononboarding.domain.SurveyItem;
+import me.dhlee.donghyeononboarding.domain.SurveyItemOption;
+import me.dhlee.donghyeononboarding.exception.AppException;
+import me.dhlee.donghyeononboarding.exception.ErrorCode;
+
+public record SurveyItemOptionCreateRequest(
+    String title,
+    int displayOrder
+) {
+    public SurveyItemOptionCreateRequest {
+        if (ObjectUtils.isEmpty(title)) {
+            throw new AppException(ErrorCode.SURVEY_ITEM_OPTION_TITLE_IS_EMPTY);
+        }
+        if (displayOrder < 0) {
+            throw new AppException(ErrorCode.DISPLAY_ORDER_IS_NEGATIVE);
+        }
+    }
+    public SurveyItemOption toEntity(SurveyItem surveyItem) {
+        return SurveyItemOption.builder()
+            .title(title)
+            .displayOrder(displayOrder)
+            .surveyItem(surveyItem)
+            .build();
+    }
+}

--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/dto/response/SurveyCreateResponse.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/dto/response/SurveyCreateResponse.java
@@ -1,0 +1,9 @@
+package me.dhlee.donghyeononboarding.dto.response;
+
+import me.dhlee.donghyeononboarding.domain.Survey;
+
+public record SurveyCreateResponse(Long surveyId) {
+    public static SurveyCreateResponse from(Survey save) {
+        return new SurveyCreateResponse(save.getId());
+    }
+}

--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/exception/AppException.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/exception/AppException.java
@@ -1,0 +1,8 @@
+package me.dhlee.donghyeononboarding.exception;
+
+public class AppException extends RuntimeException {
+
+    public AppException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+    }
+}

--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/exception/ErrorCode.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/exception/ErrorCode.java
@@ -18,7 +18,7 @@ public enum ErrorCode {
     SURVEY_ITEM_OPTION_TITLE_IS_EMPTY("설문조사 항목 옵션 제목은 필수 입력사항입니다."),
     SURVEY_ITEM_OPTION_IS_EMPTY("설문조사 항목 옵션은 필수 입력사항입니다."),
     SURVEY_ITEM_OPTION_SIZE_OVERFLOW("설문조사 항목 옵션은 최대 10개까지 가능합니다."),
-    NOT_SELECTABLE_ITEM_TYPE_SHOULD_HAVE_NOT_OPTIONS("단답형, 장문형 항목은 설문조사 항목을 가질 수 없습니다."),
+    NOT_SELECTABLE_ITEM_TYPE_SHOULD_HAVE_NOT_OPTIONS("비선택형 항목은 설문조사 항목을 가질 수 없습니다."),
 
     DISPLAY_ORDER_IS_NEGATIVE("항목 표시순서는 0 이상이어야 합니다."),
 

--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/exception/ErrorCode.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/exception/ErrorCode.java
@@ -1,0 +1,10 @@
+package me.dhlee.donghyeononboarding.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    private final String message;
+}

--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/exception/ErrorCode.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/exception/ErrorCode.java
@@ -6,5 +6,22 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+    SURVEY_TITLE_IS_EMPTY("설문조사 제목은 필수 입력사항입니다."),
+    SURVEY_DESCRIPTION_IS_EMPTY("설문조사 설명은 필수 입력사항입니다."),
+
+    SURVEY_ITEM_TITLE_IS_EMPTY("설문조사 항목 제목은 필수 입력사항입니다."),
+    SURVEY_ITEM_DESCRIPTION_IS_EMPTY("설문조사 항목 설명은 필수 입력사항입니다."),
+    SURVEY_ITEM_TYPE_IS_EMPTY("설문조사 항목 타입은 필수 입력사항입니다."),
+    SURVEY_ITEM_IS_EMPTY("설문조사 항목은 필수 입력사항입니다."),
+    SURVEY_ITEM_SIZE_OVERFLOW("설문조사 항목은 최대 10개까지 가능합니다."),
+
+    SURVEY_ITEM_OPTION_TITLE_IS_EMPTY("설문조사 항목 옵션 제목은 필수 입력사항입니다."),
+    SURVEY_ITEM_OPTION_IS_EMPTY("설문조사 항목 옵션은 필수 입력사항입니다."),
+    SURVEY_ITEM_OPTION_SIZE_OVERFLOW("설문조사 항목 옵션은 최대 10개까지 가능합니다."),
+    NOT_SELECTABLE_ITEM_TYPE_SHOULD_HAVE_NOT_OPTIONS("단답형, 장문형 항목은 설문조사 항목을 가질 수 없습니다."),
+
+    DISPLAY_ORDER_IS_NEGATIVE("항목 표시순서는 0 이상이어야 합니다."),
+
+    ;
     private final String message;
 }

--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/exception/GlobalExceptionHandler.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/exception/GlobalExceptionHandler.java
@@ -1,0 +1,15 @@
+package me.dhlee.donghyeononboarding.exception;
+
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import me.dhlee.donghyeononboarding.common.ApiResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(AppException.class)
+    public ApiResponse<Void> handleAppException(AppException e) {
+        return ApiResponse.badRequest(e.getMessage());
+    }
+}

--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/mapper/SurveyMapper.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/mapper/SurveyMapper.java
@@ -1,0 +1,28 @@
+package me.dhlee.donghyeononboarding.mapper;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import me.dhlee.donghyeononboarding.domain.Survey;
+import me.dhlee.donghyeononboarding.domain.SurveyItem;
+import me.dhlee.donghyeononboarding.dto.request.SurveyCreateRequest;
+import me.dhlee.donghyeononboarding.dto.request.SurveyItemCreateRequest;
+import me.dhlee.donghyeononboarding.dto.request.SurveyItemOptionCreateRequest;
+
+@Component
+public class SurveyMapper {
+
+    public Survey toEntity(SurveyCreateRequest request) {
+        Survey survey = request.toEntity();
+        for (SurveyItemCreateRequest item : request.items()) {
+            SurveyItem surveyItem = item.toEntity(survey);
+            List<SurveyItemOptionCreateRequest> options = item.options();
+            for (SurveyItemOptionCreateRequest option : options) {
+                surveyItem.addOption(option.toEntity(surveyItem));
+            }
+            survey.addItem(surveyItem);
+        }
+        return survey;
+    }
+}

--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/repository/SurveyRepository.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/repository/SurveyRepository.java
@@ -1,0 +1,8 @@
+package me.dhlee.donghyeononboarding.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import me.dhlee.donghyeononboarding.domain.Survey;
+
+public interface SurveyRepository extends JpaRepository<Survey, Long> {
+
+}

--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/service/SurveyService.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/service/SurveyService.java
@@ -1,0 +1,34 @@
+package me.dhlee.donghyeononboarding.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.ObjectUtils;
+
+import lombok.RequiredArgsConstructor;
+import me.dhlee.donghyeononboarding.domain.Survey;
+import me.dhlee.donghyeononboarding.domain.SurveyItem;
+import me.dhlee.donghyeononboarding.domain.SurveyItemOption;
+import me.dhlee.donghyeononboarding.dto.request.SurveyCreateRequest;
+import me.dhlee.donghyeononboarding.dto.request.SurveyItemCreateRequest;
+import me.dhlee.donghyeononboarding.dto.request.SurveyItemOptionCreateRequest;
+import me.dhlee.donghyeononboarding.dto.response.SurveyCreateResponse;
+import me.dhlee.donghyeononboarding.exception.AppException;
+import me.dhlee.donghyeononboarding.exception.ErrorCode;
+import me.dhlee.donghyeononboarding.mapper.SurveyMapper;
+import me.dhlee.donghyeononboarding.repository.SurveyRepository;
+
+@RequiredArgsConstructor
+@Service
+public class SurveyService {
+
+    private final SurveyRepository surveyRepository;
+    private final SurveyMapper surveyMapper;
+
+    @Transactional
+    public SurveyCreateResponse createSurvey(SurveyCreateRequest request) {
+        Survey survey = surveyMapper.toEntity(request);
+        return SurveyCreateResponse.from(surveyRepository.save(survey));
+    }
+}

--- a/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/web/SurveyApiController.java
+++ b/project/donghyeon-onboarding/src/main/java/me/dhlee/donghyeononboarding/web/SurveyApiController.java
@@ -1,0 +1,25 @@
+package me.dhlee.donghyeononboarding.web;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import me.dhlee.donghyeononboarding.dto.request.SurveyCreateRequest;
+import me.dhlee.donghyeononboarding.dto.response.SurveyCreateResponse;
+import me.dhlee.donghyeononboarding.common.ApiResponse;
+import me.dhlee.donghyeononboarding.service.SurveyService;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/surveys")
+@RestController
+public class SurveyApiController {
+
+    private final SurveyService surveyService;
+
+    @PostMapping
+    public ApiResponse<SurveyCreateResponse> createSurvey(@RequestBody SurveyCreateRequest request) {
+        return ApiResponse.ok(surveyService.createSurvey(request));
+    }
+}

--- a/project/donghyeon-onboarding/src/main/resources/application.yml
+++ b/project/donghyeon-onboarding/src/main/resources/application.yml
@@ -1,2 +1,21 @@
+logging:
+  level:
+    org.hibernate:
+      sql: debug
+      orm.jdbc.bind: trace
 spring:
   application.name: donghyeon-onboarding
+  h2:
+    console.enabled: true
+  datasource:
+    url: jdbc:h2:mem:survey
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: aa
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate.format_sql: true

--- a/project/donghyeon-onboarding/src/test/java/me/dhlee/donghyeononboarding/dto/request/SurveyCreateRequestTest.java
+++ b/project/donghyeon-onboarding/src/test/java/me/dhlee/donghyeononboarding/dto/request/SurveyCreateRequestTest.java
@@ -1,0 +1,61 @@
+package me.dhlee.donghyeononboarding.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import me.dhlee.donghyeononboarding.domain.ItemType;
+import me.dhlee.donghyeononboarding.exception.AppException;
+import me.dhlee.donghyeononboarding.exception.ErrorCode;
+
+class SurveyCreateRequestTest {
+
+    @DisplayName("설문조사 제목이 비어있으면 예외가 발생한다.")
+    @Test
+    void createSurveyWithEmptyTitle() {
+        var option = new SurveyItemOptionCreateRequest("옵션1", 0);
+        var item = new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.MULTI_SELECT, true, 0, List.of(option));
+
+        assertThatThrownBy(() -> new SurveyCreateRequest("", "설문 설명", List.of(item)))
+            .isInstanceOf(AppException.class)
+            .hasMessage(ErrorCode.SURVEY_TITLE_IS_EMPTY.getMessage());
+    }
+
+    @DisplayName("설문조사 설명이 비어있으면 예외가 발생한다.")
+    @Test
+    void createSurveyWithEmptyDescription() {
+        var option = new SurveyItemOptionCreateRequest("옵션1", 0);
+        var item = new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.MULTI_SELECT, true, 0, List.of(option));
+
+        assertThatThrownBy(() -> new SurveyCreateRequest("설문 제목", "", List.of(item)))
+            .isInstanceOf(AppException.class)
+            .hasMessage(ErrorCode.SURVEY_DESCRIPTION_IS_EMPTY.getMessage());
+    }
+
+    @DisplayName("설문조사 항목이 비어있으면 예외가 발생한다.")
+    @Test
+    void createSurveyWithEmptyItems() {
+        assertThatThrownBy(() -> new SurveyCreateRequest("설문 제목", "설문 설명", Collections.emptyList()))
+            .isInstanceOf(AppException.class)
+            .hasMessage(ErrorCode.SURVEY_ITEM_IS_EMPTY.getMessage());
+    }
+
+    @DisplayName("설문조사 항목이 10개를 초과하면 예외가 발생한다.")
+    @Test
+    void createSurveyWithTooManyItems() {
+        var option = new SurveyItemOptionCreateRequest("옵션1", 0);
+        var item = new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.MULTI_SELECT, true, 0, List.of(option));
+        var items = IntStream.rangeClosed(0, 10)
+            .mapToObj(i -> item)
+            .toList();
+
+        assertThatThrownBy(() -> new SurveyCreateRequest("설문 제목", "설문 설명", items))
+            .isInstanceOf(AppException.class)
+            .hasMessage(ErrorCode.SURVEY_ITEM_SIZE_OVERFLOW.getMessage());
+    }
+}

--- a/project/donghyeon-onboarding/src/test/java/me/dhlee/donghyeononboarding/dto/request/SurveyItemCreateRequestTest.java
+++ b/project/donghyeon-onboarding/src/test/java/me/dhlee/donghyeononboarding/dto/request/SurveyItemCreateRequestTest.java
@@ -1,0 +1,154 @@
+package me.dhlee.donghyeononboarding.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import me.dhlee.donghyeononboarding.domain.ItemType;
+import me.dhlee.donghyeononboarding.exception.AppException;
+import me.dhlee.donghyeononboarding.exception.ErrorCode;
+
+class SurveyItemCreateRequestTest {
+
+    @DisplayName("설문조사 항목 제목이 비어있으면 예외가 발생한다.")
+    @Test
+    void createSurveyWithEmptyItemTitle() {
+        var option = new SurveyItemOptionCreateRequest("옵션1", 0);
+
+        assertThatThrownBy(
+            () -> new SurveyItemCreateRequest("", "질문 설명1", ItemType.MULTI_SELECT, true, 0, List.of(option)))
+            .isInstanceOf(AppException.class)
+            .hasMessage(ErrorCode.SURVEY_ITEM_TITLE_IS_EMPTY.getMessage());
+    }
+
+    @DisplayName("설문조사 항목 설명이 비어있으면 예외가 발생한다.")
+    @Test
+    void createSurveyWithEmptyItemDescription() {
+        var option = new SurveyItemOptionCreateRequest("옵션1", 0);
+
+        assertThatThrownBy(
+            () -> new SurveyItemCreateRequest("질문1", "", ItemType.MULTI_SELECT, true, 0, List.of(option)))
+            .isInstanceOf(AppException.class)
+            .hasMessage(ErrorCode.SURVEY_ITEM_DESCRIPTION_IS_EMPTY.getMessage());
+    }
+
+    @DisplayName("설문조사 항목 타입이 비어있으면 예외가 발생한다.")
+    @Test
+    void createSurveyWithNullItemType() {
+        var option = new SurveyItemOptionCreateRequest("옵션1", 0);
+
+        assertThatThrownBy(() -> new SurveyItemCreateRequest("질문1", "질문 설명1", null, true, 0, List.of(option)))
+            .isInstanceOf(AppException.class)
+            .hasMessage(ErrorCode.SURVEY_ITEM_TYPE_IS_EMPTY.getMessage());
+    }
+
+    @DisplayName("설문조사 항목 표시순서가 음수이면 예외가 발생한다.")
+    @Test
+    void createSurveyWithNegativeItemDisplayOrder() {
+        var option = new SurveyItemOptionCreateRequest("옵션1", 0);
+
+        assertThatThrownBy(
+            () -> new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.MULTI_SELECT, true, -1, List.of(option)))
+            .isInstanceOf(AppException.class)
+            .hasMessage(ErrorCode.DISPLAY_ORDER_IS_NEGATIVE.getMessage());
+    }
+
+    @DisplayName("선택형 항목(SINGLE_SELECT, MULTI_SELECT)이고 옵션이 비어있으면 예외가 발생한다.")
+    @Test
+    void createSurveyWithSelectableItemTypeAndEmptyOptions() {
+        // SINGLE_SELECT 테스트
+        assertThatThrownBy(
+            () -> new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.SINGLE_SELECT, true, 0, Collections.emptyList()))
+            .isInstanceOf(AppException.class)
+            .hasMessage(ErrorCode.SURVEY_ITEM_OPTION_IS_EMPTY.getMessage());
+
+        // MULTI_SELECT 테스트
+        assertThatThrownBy(
+            () -> new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.MULTI_SELECT, true, 0, Collections.emptyList()))
+            .isInstanceOf(AppException.class)
+            .hasMessage(ErrorCode.SURVEY_ITEM_OPTION_IS_EMPTY.getMessage());
+    }
+
+    @DisplayName("선택형 항목(SINGLE_SELECT, MULTI_SELECT)이고 옵션이 10개 이상이면 예외가 발생한다.")
+    @Test
+    void createSurveyWithSelectableItemTypeAndTooManyOptions() {
+        // 10개의 옵션 생성
+        List<SurveyItemOptionCreateRequest> options = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            options.add(new SurveyItemOptionCreateRequest("옵션" + i, i));
+        }
+
+        // SINGLE_SELECT 테스트
+        assertThatThrownBy(
+            () -> new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.SINGLE_SELECT, true, 0, options))
+            .isInstanceOf(AppException.class)
+            .hasMessage(ErrorCode.SURVEY_ITEM_OPTION_SIZE_OVERFLOW.getMessage());
+
+        // MULTI_SELECT 테스트
+        assertThatThrownBy(
+            () -> new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.MULTI_SELECT, true, 0, options))
+            .isInstanceOf(AppException.class)
+            .hasMessage(ErrorCode.SURVEY_ITEM_OPTION_SIZE_OVERFLOW.getMessage());
+    }
+
+    @DisplayName("선택형 항목(SINGLE_SELECT, MULTI_SELECT)이고 옵션이 유효하면 예외가 발생하지 않는다.")
+    @Test
+    void createSurveyWithSelectableItemTypeAndValidOptions() {
+        // 유효한 옵션 (1~9개)
+        List<SurveyItemOptionCreateRequest> options = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            options.add(new SurveyItemOptionCreateRequest("옵션" + i, i));
+        }
+
+        // SINGLE_SELECT 테스트
+        assertThatCode(
+            () -> new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.SINGLE_SELECT, true, 0, options))
+            .doesNotThrowAnyException();
+
+        // MULTI_SELECT 테스트
+        assertThatCode(
+            () -> new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.MULTI_SELECT, true, 0, options))
+            .doesNotThrowAnyException();
+    }
+
+    @DisplayName("비선택형 항목(SHORT_TEXT, LONG_TEXT)이고 옵션이 비어있지 않으면 예외가 발생한다.")
+    @Test
+    void createSurveyWithNonSelectableItemTypeAndNonEmptyOptions() {
+        var option = new SurveyItemOptionCreateRequest("옵션1", 0);
+
+        // SHORT_TEXT 테스트
+        assertThatThrownBy(
+            () -> new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.SHORT_TEXT, true, 0, List.of(option)))
+            .isInstanceOf(AppException.class)
+            .hasMessage(ErrorCode.NOT_SELECTABLE_ITEM_TYPE_SHOULD_HAVE_NOT_OPTIONS.getMessage());
+
+        // LONG_TEXT 테스트
+        assertThatThrownBy(
+            () -> new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.LONG_TEXT, true, 0, List.of(option)))
+            .isInstanceOf(AppException.class)
+            .hasMessage(ErrorCode.NOT_SELECTABLE_ITEM_TYPE_SHOULD_HAVE_NOT_OPTIONS.getMessage());
+    }
+
+    @DisplayName("비선택형 항목(SHORT_TEXT, LONG_TEXT)이고 옵션이 비어있으면 예외가 발생하지 않는다.")
+    @Test
+    void createSurveyWithNonSelectableItemTypeAndEmptyOptions() {
+        // SHORT_TEXT 테스트
+        assertThatCode(
+            () -> new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.SHORT_TEXT, true, 0, Collections.emptyList()))
+            .doesNotThrowAnyException();
+
+        // LONG_TEXT 테스트
+        assertThatCode(
+            () -> new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.LONG_TEXT, true, 0, Collections.emptyList()))
+            .doesNotThrowAnyException();
+    }
+
+
+}

--- a/project/donghyeon-onboarding/src/test/java/me/dhlee/donghyeononboarding/dto/request/SurveyItemCreateRequestTest.java
+++ b/project/donghyeon-onboarding/src/test/java/me/dhlee/donghyeononboarding/dto/request/SurveyItemCreateRequestTest.java
@@ -1,9 +1,7 @@
 package me.dhlee.donghyeononboarding.dto.request;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -65,7 +63,8 @@ class SurveyItemCreateRequestTest {
     void createSurveyWithSelectableItemTypeAndEmptyOptions() {
         // SINGLE_SELECT 테스트
         assertThatThrownBy(
-            () -> new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.SINGLE_SELECT, true, 0, Collections.emptyList()))
+            () -> new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.SINGLE_SELECT, true, 0,
+                Collections.emptyList()))
             .isInstanceOf(AppException.class)
             .hasMessage(ErrorCode.SURVEY_ITEM_OPTION_IS_EMPTY.getMessage());
 
@@ -79,11 +78,9 @@ class SurveyItemCreateRequestTest {
     @DisplayName("선택형 항목(SINGLE_SELECT, MULTI_SELECT)이고 옵션이 10개 이상이면 예외가 발생한다.")
     @Test
     void createSurveyWithSelectableItemTypeAndTooManyOptions() {
-        // 10개의 옵션 생성
-        List<SurveyItemOptionCreateRequest> options = new ArrayList<>();
-        for (int i = 0; i < 10; i++) {
-            options.add(new SurveyItemOptionCreateRequest("옵션" + i, i));
-        }
+        var options = IntStream.rangeClosed(0, 10)
+            .mapToObj(i -> new SurveyItemOptionCreateRequest("옵션" + i, i))
+            .toList();
 
         // SINGLE_SELECT 테스트
         assertThatThrownBy(
@@ -96,26 +93,6 @@ class SurveyItemCreateRequestTest {
             () -> new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.MULTI_SELECT, true, 0, options))
             .isInstanceOf(AppException.class)
             .hasMessage(ErrorCode.SURVEY_ITEM_OPTION_SIZE_OVERFLOW.getMessage());
-    }
-
-    @DisplayName("선택형 항목(SINGLE_SELECT, MULTI_SELECT)이고 옵션이 유효하면 예외가 발생하지 않는다.")
-    @Test
-    void createSurveyWithSelectableItemTypeAndValidOptions() {
-        // 유효한 옵션 (1~9개)
-        List<SurveyItemOptionCreateRequest> options = new ArrayList<>();
-        for (int i = 0; i < 5; i++) {
-            options.add(new SurveyItemOptionCreateRequest("옵션" + i, i));
-        }
-
-        // SINGLE_SELECT 테스트
-        assertThatCode(
-            () -> new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.SINGLE_SELECT, true, 0, options))
-            .doesNotThrowAnyException();
-
-        // MULTI_SELECT 테스트
-        assertThatCode(
-            () -> new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.MULTI_SELECT, true, 0, options))
-            .doesNotThrowAnyException();
     }
 
     @DisplayName("비선택형 항목(SHORT_TEXT, LONG_TEXT)이고 옵션이 비어있지 않으면 예외가 발생한다.")
@@ -135,20 +112,4 @@ class SurveyItemCreateRequestTest {
             .isInstanceOf(AppException.class)
             .hasMessage(ErrorCode.NOT_SELECTABLE_ITEM_TYPE_SHOULD_HAVE_NOT_OPTIONS.getMessage());
     }
-
-    @DisplayName("비선택형 항목(SHORT_TEXT, LONG_TEXT)이고 옵션이 비어있으면 예외가 발생하지 않는다.")
-    @Test
-    void createSurveyWithNonSelectableItemTypeAndEmptyOptions() {
-        // SHORT_TEXT 테스트
-        assertThatCode(
-            () -> new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.SHORT_TEXT, true, 0, Collections.emptyList()))
-            .doesNotThrowAnyException();
-
-        // LONG_TEXT 테스트
-        assertThatCode(
-            () -> new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.LONG_TEXT, true, 0, Collections.emptyList()))
-            .doesNotThrowAnyException();
-    }
-
-
 }

--- a/project/donghyeon-onboarding/src/test/java/me/dhlee/donghyeononboarding/dto/request/SurveyItemOptionCreateRequestTest.java
+++ b/project/donghyeon-onboarding/src/test/java/me/dhlee/donghyeononboarding/dto/request/SurveyItemOptionCreateRequestTest.java
@@ -1,0 +1,29 @@
+package me.dhlee.donghyeononboarding.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import me.dhlee.donghyeononboarding.exception.AppException;
+import me.dhlee.donghyeononboarding.exception.ErrorCode;
+
+class SurveyItemOptionCreateRequestTest {
+
+    @DisplayName("설문조사 항목 옵션 제목이 비어있으면 예외가 발생한다.")
+    @Test
+    void createSurveyWithEmptyOptionTitle() {
+        assertThatThrownBy(() -> new SurveyItemOptionCreateRequest("", 0))
+            .isInstanceOf(AppException.class)
+            .hasMessage(ErrorCode.SURVEY_ITEM_OPTION_TITLE_IS_EMPTY.getMessage());
+    }
+
+    @DisplayName("설문조사 항목 옵션 표시순서가 음수이면 예외가 발생한다.")
+    @Test
+    void createSurveyWithNegativeOptionDisplayOrder() {
+        assertThatThrownBy(() -> new SurveyItemOptionCreateRequest("옵션1", -1))
+            .isInstanceOf(AppException.class)
+            .hasMessage(ErrorCode.DISPLAY_ORDER_IS_NEGATIVE.getMessage());
+    }
+
+}

--- a/project/donghyeon-onboarding/src/test/java/me/dhlee/donghyeononboarding/service/SurveyServiceTest.java
+++ b/project/donghyeon-onboarding/src/test/java/me/dhlee/donghyeononboarding/service/SurveyServiceTest.java
@@ -1,0 +1,56 @@
+package me.dhlee.donghyeononboarding.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import me.dhlee.donghyeononboarding.domain.ItemType;
+import me.dhlee.donghyeononboarding.domain.Survey;
+import me.dhlee.donghyeononboarding.dto.request.SurveyCreateRequest;
+import me.dhlee.donghyeononboarding.dto.request.SurveyItemCreateRequest;
+import me.dhlee.donghyeononboarding.dto.request.SurveyItemOptionCreateRequest;
+import me.dhlee.donghyeononboarding.exception.AppException;
+import me.dhlee.donghyeononboarding.exception.ErrorCode;
+import me.dhlee.donghyeononboarding.repository.SurveyRepository;
+
+@SpringBootTest
+class SurveyServiceTest {
+
+    @Autowired
+    protected SurveyService surveyService;
+
+    @Autowired
+    protected SurveyRepository surveyRepository;
+
+    @BeforeEach
+    void setUp() {
+        surveyRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("설문조사를 생성할 수 있다.")
+    @Test
+    void createSurvey() {
+        var option = new SurveyItemOptionCreateRequest("옵션1", 0);
+        var item = new SurveyItemCreateRequest("질문1", "질문 설명1", ItemType.MULTI_SELECT, true, 0, List.of(option));
+        var request = new SurveyCreateRequest("설문 제목", "설문 설명", List.of(item));
+
+        var result = surveyService.createSurvey(request);
+
+        assertThat(result).isNotNull();
+
+        List<Survey> all = surveyRepository.findAll();
+        assertThat(all).hasSize(1);
+        assertThat(all.get(0).getTitle()).isEqualTo("설문 제목");
+        assertThat(all.get(0).getDescription()).isEqualTo("설문 설명");
+    }
+}


### PR DESCRIPTION
## Goal

- 설문조사 생성 API 개발 및 테스트

## Changes

chore: H2 DB 설정 및 JPA SQL 로그 설정: f343fd9

feat: 설문조사 도메인 엔티티 추가: 3ac32f4
feat: 공통 응답 및 예외 처리 포맷 추가: 0266969
feat: 설문조사 생성 API 추가: f36c126
refactor: 비선택형 항목에 대한 예외 메시지 수정: 5ee4002

test: 설문조사 생성 API 테스트: 619f68c
test: 설문조사 항목 생성 요청 DTO 테스트 수정: 05d67b6

## Description

도메인의 깊이가 3 단계인 것은 처음이라 제대로 한 것인지 자신이 없네요.
특히나 DTO에서 Entity로 변환하는 부분이 많이 신경쓰입니다.
