### PR TITLE
설문조사 응답 제출 추가

### DIFF
--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/controller/SurveyController.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/controller/SurveyController.kt
@@ -20,7 +20,7 @@ class SurveyController(
                 id = survey.id!!,
                 title = survey.title,
                 description = survey.description,
-                item = survey.questions.map {
+                item = survey.getQuestions().map {
                     QuestionDto.of(it)
                 }.toList()
             )
@@ -36,7 +36,7 @@ class SurveyController(
                 id = survey.id!!,
                 title = survey.title,
                 description = survey.description,
-                item = survey.questions.map {
+                item = survey.getQuestions().map {
                     QuestionDto.of(it)
                 }.toList()
             )

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/controller/SurveyController.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/controller/SurveyController.kt
@@ -1,5 +1,6 @@
 package com.onboarding.form.controller
 
+import CreateAnswerRequestDto
 import com.onboarding.form.request.CreateSurveyDto
 import com.onboarding.form.response.SurveyDto
 import com.onboarding.form.service.SurveyService
@@ -19,9 +20,17 @@ class SurveyController(
 
     @PutMapping("/surveys/{id}")
     fun update(@RequestBody surveyDto: CreateSurveyDto, @PathVariable id: Long): ResponseEntity<SurveyDto> {
-        val survey = service.updateSurveyDto(id, surveyDto)
-
+        val survey = service.updateSurvey(id, surveyDto)
         return ResponseEntity.ok(SurveyDto.of(survey))
+    }
+
+    @PutMapping("/surveys/{id}/submit")
+    fun submitAnswers(
+        @RequestBody createAnswerRequestDto: CreateAnswerRequestDto,
+        @PathVariable id: Long
+    ): ResponseEntity<Nothing> {
+        service.submitAnswer(surveyId = id, createAnswerRequestDto)
+        return ResponseEntity.ok(null)
     }
 }
 

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/controller/SurveyController.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/controller/SurveyController.kt
@@ -5,9 +5,7 @@ import com.onboarding.form.response.QuestionDto
 import com.onboarding.form.response.SurveyDto
 import com.onboarding.form.service.SurveyService
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 class SurveyController(
@@ -16,6 +14,22 @@ class SurveyController(
     @PostMapping("/surveys")
     fun create(@RequestBody surveyDto: CreateSurveyDto): ResponseEntity<SurveyDto> {
         val survey = service.createSurvey(surveyDto)
+
+        return ResponseEntity.ok(
+            SurveyDto(
+                id = survey.id!!,
+                title = survey.title,
+                description = survey.description,
+                item = survey.questions.map {
+                    QuestionDto.of(it)
+                }.toList()
+            )
+        )
+    }
+
+    @PutMapping("/surveys/{id}")
+    fun update(@RequestBody surveyDto: CreateSurveyDto, @PathVariable id: Long): ResponseEntity<SurveyDto> {
+        val survey = service.updateSurveyDto(id, surveyDto)
 
         return ResponseEntity.ok(
             SurveyDto(

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/controller/SurveyController.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/controller/SurveyController.kt
@@ -1,7 +1,6 @@
 package com.onboarding.form.controller
 
 import com.onboarding.form.request.CreateSurveyDto
-import com.onboarding.form.response.QuestionDto
 import com.onboarding.form.response.SurveyDto
 import com.onboarding.form.service.SurveyService
 import org.springframework.http.ResponseEntity
@@ -15,32 +14,14 @@ class SurveyController(
     fun create(@RequestBody surveyDto: CreateSurveyDto): ResponseEntity<SurveyDto> {
         val survey = service.createSurvey(surveyDto)
 
-        return ResponseEntity.ok(
-            SurveyDto(
-                id = survey.id!!,
-                title = survey.title,
-                description = survey.description,
-                item = survey.getQuestions().map {
-                    QuestionDto.of(it)
-                }.toList()
-            )
-        )
+        return ResponseEntity.ok(SurveyDto.of(survey))
     }
 
     @PutMapping("/surveys/{id}")
     fun update(@RequestBody surveyDto: CreateSurveyDto, @PathVariable id: Long): ResponseEntity<SurveyDto> {
         val survey = service.updateSurveyDto(id, surveyDto)
 
-        return ResponseEntity.ok(
-            SurveyDto(
-                id = survey.id!!,
-                title = survey.title,
-                description = survey.description,
-                item = survey.getQuestions().map {
-                    QuestionDto.of(it)
-                }.toList()
-            )
-        )
+        return ResponseEntity.ok(SurveyDto.of(survey))
     }
 }
 

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/Answer.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/Answer.kt
@@ -1,0 +1,56 @@
+package com.onboarding.form.domain
+
+import CreateAnswerDto
+import CreateInsertAnswerDto
+import CreateSelectAnswerDto
+import jakarta.persistence.*
+
+
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(
+    name = "type",
+    discriminatorType = DiscriminatorType.STRING
+)
+@Table(name = "answer")
+abstract class Answer(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    open val id: Long = 0,
+    @Column(name = "question_id", nullable = false)
+    open val questionId: Long,
+) {
+    companion object {
+        fun of(answerDto: CreateAnswerDto) = when (answerDto) {
+            is CreateInsertAnswerDto -> InsertAnswer.of(answerDto)
+            is CreateSelectAnswerDto -> SelectAnswer.of(answerDto)
+            else -> throw IllegalArgumentException("is not valid response type")
+        }
+    }
+}
+
+@Entity
+@DiscriminatorValue("insert")
+class InsertAnswer(
+    id: Long = 0,
+    questionId: Long,
+    val content: String,
+) : Answer(id, questionId) {
+    companion object {
+        fun of(answerDto: CreateInsertAnswerDto) = InsertAnswer(0, answerDto.questionId, answerDto.content)
+    }
+}
+
+@Entity
+@DiscriminatorValue("select")
+class SelectAnswer(
+    id: Long = 0,
+    questionId: Long,
+    @ElementCollection
+    @CollectionTable
+    val selected: List<String>,
+) : Answer(id, questionId) {
+    companion object {
+        fun of(answerDto: CreateSelectAnswerDto) = SelectAnswer(0, answerDto.questionId, answerDto.selected)
+    }
+}

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/Question.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/Question.kt
@@ -21,8 +21,8 @@ abstract class Question(
     val description: String,
     val isRequired: Boolean,
     @ManyToOne
-    @JoinColumn(name = "survey_id")
-    var survey: Survey? = null
+    @JoinColumn(name = "survey_version_id")
+    var surveyVersion: SurveyVersion? = null
 ) {
     abstract fun getType(): QuestionType
 
@@ -67,13 +67,13 @@ class LongQuestion(
     title: String,
     description: String,
     isRequired: Boolean,
-    survey: Survey? = null
+    surveyVersion: SurveyVersion? = null
 ) : Question(
     id,
     title,
     description,
     isRequired,
-    survey
+    surveyVersion
 ) {
     override fun getType(): QuestionType = QuestionType.LONG
 }
@@ -85,13 +85,13 @@ class ShortQuestion(
     title: String,
     description: String,
     isRequired: Boolean,
-    survey: Survey? = null
+    surveyVersion: SurveyVersion? = null
 ) : Question(
     id,
     title,
     description,
     isRequired,
-    survey
+    surveyVersion
 ) {
     override fun getType(): QuestionType = QuestionType.SHORT
 }
@@ -106,13 +106,13 @@ class SingleSelectQuestion(
     @ElementCollection
     @CollectionTable
     val answerList: List<String>,
-    survey: Survey? = null
+    surveyVersion: SurveyVersion? = null
 ) : Question(
     id,
     title,
     description,
     isRequired,
-    survey
+    surveyVersion
 ) {
     override fun getType(): QuestionType = QuestionType.SINGLE_SELECT
 }
@@ -127,13 +127,13 @@ class MultiSelectQuestion(
     @ElementCollection
     @CollectionTable
     val answerList: List<String>,
-    survey: Survey? = null
+    surveyVersion: SurveyVersion? = null
 ) : Question(
     id,
     title,
     description,
     isRequired,
-    survey
+    surveyVersion
 ) {
     override fun getType(): QuestionType = QuestionType.MULTI_SELECT
 }

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/Question.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/Question.kt
@@ -1,5 +1,8 @@
 package com.onboarding.form.domain
 
+import com.onboarding.form.request.CreateQuestionDto
+import com.onboarding.form.request.CreateSelectQuestionDto
+import com.onboarding.form.request.CreateStandardQuestionDto
 import jakarta.persistence.*
 
 
@@ -9,7 +12,7 @@ import jakarta.persistence.*
     name = "type",
     discriminatorType = DiscriminatorType.STRING
 )
-@Table(name = "question")
+@Table(name = "questions")
 abstract class Question(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,6 +25,38 @@ abstract class Question(
     var survey: Survey? = null
 ) {
     abstract fun getType(): QuestionType
+
+    companion object {
+        fun of(question: CreateQuestionDto): Question {
+            return when (question) {
+                is CreateStandardQuestionDto -> when (question.type) {
+                    QuestionType.SHORT -> ShortQuestion(null, question.title, question.description, question.isRequired)
+                    QuestionType.LONG -> LongQuestion(null, question.title, question.description, question.isRequired)
+                    else -> throw IllegalArgumentException("Question type ${question.type} not supported")
+                }
+
+                is CreateSelectQuestionDto -> when (question.type) {
+                    QuestionType.SINGLE_SELECT -> SingleSelectQuestion(
+                        null,
+                        question.title,
+                        question.description,
+                        question.isRequired,
+                        question.answerList
+                    )
+
+                    QuestionType.MULTI_SELECT -> MultiSelectQuestion(
+                        null,
+                        question.title,
+                        question.description,
+                        question.isRequired,
+                        question.answerList
+                    )
+
+                    else -> throw IllegalArgumentException("Question type ${question.type} not supported")
+                }
+            }
+        }
+    }
 }
 
 

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/Question.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/Question.kt
@@ -16,13 +16,13 @@ import jakarta.persistence.*
 abstract class Question(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0,
-    val title: String,
-    val description: String,
-    val isRequired: Boolean,
+    open val id: Long = 0,
+    open val title: String,
+    open val description: String,
+    open val isRequired: Boolean,
     @ManyToOne
     @JoinColumn(name = "survey_version_id")
-    var surveyVersion: SurveyVersion? = null
+    open var surveyVersion: SurveyVersion? = null
 ) {
     @get:Transient
     abstract val type: QuestionType

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/Question.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/Question.kt
@@ -9,14 +9,14 @@ import jakarta.persistence.*
 @Entity
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(
-    name = "type",
+    name = "question_type",
     discriminatorType = DiscriminatorType.STRING
 )
 @Table(name = "questions")
 abstract class Question(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null,
+    val id: Long = 0,
     val title: String,
     val description: String,
     val isRequired: Boolean,
@@ -24,20 +24,23 @@ abstract class Question(
     @JoinColumn(name = "survey_version_id")
     var surveyVersion: SurveyVersion? = null
 ) {
-    abstract fun getType(): QuestionType
+    @get:Transient
+    abstract val type: QuestionType
+
+    abstract fun isValidAnswer(answer: Answer)
 
     companion object {
         fun of(question: CreateQuestionDto): Question {
             return when (question) {
                 is CreateStandardQuestionDto -> when (question.type) {
-                    QuestionType.SHORT -> ShortQuestion(null, question.title, question.description, question.isRequired)
-                    QuestionType.LONG -> LongQuestion(null, question.title, question.description, question.isRequired)
+                    QuestionType.SHORT -> ShortQuestion(0, question.title, question.description, question.isRequired)
+                    QuestionType.LONG -> LongQuestion(0, question.title, question.description, question.isRequired)
                     else -> throw IllegalArgumentException("Question type ${question.type} not supported")
                 }
 
                 is CreateSelectQuestionDto -> when (question.type) {
                     QuestionType.SINGLE_SELECT -> SingleSelectQuestion(
-                        null,
+                        0,
                         question.title,
                         question.description,
                         question.isRequired,
@@ -45,7 +48,7 @@ abstract class Question(
                     )
 
                     QuestionType.MULTI_SELECT -> MultiSelectQuestion(
-                        null,
+                        0,
                         question.title,
                         question.description,
                         question.isRequired,
@@ -63,7 +66,7 @@ abstract class Question(
 @Entity
 @DiscriminatorValue(QuestionType.LONG_VALUE)
 class LongQuestion(
-    id: Long? = null,
+    id: Long = 0,
     title: String,
     description: String,
     isRequired: Boolean,
@@ -75,13 +78,16 @@ class LongQuestion(
     isRequired,
     surveyVersion
 ) {
-    override fun getType(): QuestionType = QuestionType.LONG
+    override val type: QuestionType = QuestionType.LONG
+    override fun isValidAnswer(answer: Answer) {
+        check(answer is InsertAnswer) { "invalid AnswerType" }
+    }
 }
 
 @Entity
 @DiscriminatorValue(QuestionType.SHORT_VALUE)
 class ShortQuestion(
-    id: Long? = null,
+    id: Long = 0,
     title: String,
     description: String,
     isRequired: Boolean,
@@ -93,13 +99,16 @@ class ShortQuestion(
     isRequired,
     surveyVersion
 ) {
-    override fun getType(): QuestionType = QuestionType.SHORT
+    override val type: QuestionType = QuestionType.SHORT
+    override fun isValidAnswer(answer: Answer) {
+        check(answer is InsertAnswer) { "invalid AnswerType" }
+    }
 }
 
 @Entity
 @DiscriminatorValue(QuestionType.SINGLE_SELECT_VALUE)
 class SingleSelectQuestion(
-    id: Long? = null,
+    id: Long = 0,
     title: String,
     description: String,
     isRequired: Boolean,
@@ -114,13 +123,18 @@ class SingleSelectQuestion(
     isRequired,
     surveyVersion
 ) {
-    override fun getType(): QuestionType = QuestionType.SINGLE_SELECT
+    override val type: QuestionType = QuestionType.SINGLE_SELECT
+    override fun isValidAnswer(answer: Answer) {
+        check(answer is SelectAnswer) { "invalid AnswerType" }
+        require(answer.selected.size == 1) { "Selected Answer is invalid" }
+        require(answerList.contains(answer.selected.first())) { "Selected Answer is not in candidates" }
+    }
 }
 
 @Entity
 @DiscriminatorValue(QuestionType.MULTI_SELECT_VALUE)
 class MultiSelectQuestion(
-    id: Long? = null,
+    id: Long = 0,
     title: String,
     description: String,
     isRequired: Boolean,
@@ -135,5 +149,12 @@ class MultiSelectQuestion(
     isRequired,
     surveyVersion
 ) {
-    override fun getType(): QuestionType = QuestionType.MULTI_SELECT
+    override val type: QuestionType = QuestionType.MULTI_SELECT
+    override fun isValidAnswer(answer: Answer) {
+        check(answer is SelectAnswer) { "invalid AnswerType" }
+        answer.selected
+            .forEach {
+                require(answerList.contains(it)) { "Selected Answer is not in candidates" }
+            }
+    }
 }

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/Survey.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/Survey.kt
@@ -7,8 +7,8 @@ import jakarta.persistence.*
 class Survey (
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
-    val title: String,
-    val description: String,
+    var title: String,
+    var description: String,
     @OneToMany(mappedBy = "survey", cascade = [CascadeType.ALL], orphanRemoval = true)
     val questions: MutableList<Question> = mutableListOf()
 ){
@@ -16,6 +16,13 @@ class Survey (
         check(questions.size < MAX_QUESTION_SIZE) { "The number of questions cannot exceed $MAX_QUESTION_SIZE" }
         question.survey = this
         this.questions.add(question)
+    }
+
+    fun update(title: String, description: String, questions: List<Question>){
+        this.title = title
+        this.description = description
+        this.questions.clear()
+        questions.forEach { addQuestion(it) }
     }
 
     companion object{

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/Survey.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/Survey.kt
@@ -44,7 +44,7 @@ class Survey(
             return Survey(
                 title = title,
                 description = description,
-                currentVersion = SurveyVersion(version = 0)
+                currentVersion = SurveyVersion(version = 1)
             )
         }
     }

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/Survey.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/Survey.kt
@@ -6,13 +6,14 @@ import jakarta.persistence.*
 @Entity
 class Survey(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null,
+    val id: Long = 0,
     var title: String,
-    var description: String,
+    var description: String
+) {
     @OneToOne(cascade = [CascadeType.ALL])
     @JoinColumn(name = "current_version_id")
-    var currentVersion: SurveyVersion
-) {
+    lateinit var currentVersion: SurveyVersion
+
     @OneToMany(mappedBy = "survey", cascade = [CascadeType.ALL])
     val versionHistory: MutableList<SurveyVersion> = mutableListOf()
 
@@ -41,11 +42,13 @@ class Survey(
         private const val MAX_QUESTION_SIZE = 10
 
         fun of(title: String, description: String): Survey {
-            return Survey(
+            val survey = Survey(
                 title = title,
-                description = description,
-                currentVersion = SurveyVersion(version = 1)
+                description = description
             )
+            survey.currentVersion = SurveyVersion.of(0, survey)
+
+            return survey
         }
     }
 }

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/SurveyVersion.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/SurveyVersion.kt
@@ -10,13 +10,22 @@ class SurveyVersion(
     var version: Int,
     @ManyToOne
     @JoinColumn(name = "survey_id")
-    val survey: Survey,
+    var survey: Survey? = null,
     @OneToMany(mappedBy = "surveyVersion", cascade = [CascadeType.ALL])
     val questions: MutableList<Question> = mutableListOf()
 ) {
     fun addQuestion(question: Question) {
         question.surveyVersion = this
         this.questions.add(question)
+    }
+
+    fun checkValid(questionIdToResponse: Map<Long, Answer>) {
+        questions.forEach { question ->
+            if (!question.isRequired) return@forEach
+            val answer =
+                requireNotNull(questionIdToResponse.getValue(question.id)) { "QuestionId ${question.id} is answer required" }
+            question.isValidAnswer(answer)
+        }
     }
 
     companion object {

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/SurveyVersion.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/SurveyVersion.kt
@@ -7,7 +7,7 @@ import jakarta.persistence.*
 class SurveyVersion(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
-    var version: Int = 0,
+    var version: Int,
     @ManyToOne
     @JoinColumn(name = "survey_id")
     var survey: Survey? = null,

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/SurveyVersion.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/SurveyVersion.kt
@@ -1,0 +1,21 @@
+package com.onboarding.form.domain
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "question_versions")
+class SurveyVersion(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+    var version: Int = 0,
+    @ManyToOne
+    @JoinColumn(name = "survey_id")
+    var survey: Survey? = null,
+    @OneToMany(mappedBy = "surveyVersion", cascade = [CascadeType.ALL])
+    val questions: MutableList<Question> = mutableListOf()
+) {
+    fun addQuestion(question: Question) {
+        question.surveyVersion = this
+        this.questions.add(question)
+    }
+}

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/SurveyVersion.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/domain/SurveyVersion.kt
@@ -6,16 +6,20 @@ import jakarta.persistence.*
 @Table(name = "question_versions")
 class SurveyVersion(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null,
+    val id: Long = 0,
     var version: Int,
     @ManyToOne
     @JoinColumn(name = "survey_id")
-    var survey: Survey? = null,
+    val survey: Survey,
     @OneToMany(mappedBy = "surveyVersion", cascade = [CascadeType.ALL])
     val questions: MutableList<Question> = mutableListOf()
 ) {
     fun addQuestion(question: Question) {
         question.surveyVersion = this
         this.questions.add(question)
+    }
+
+    companion object {
+        fun of(version: Int, survey: Survey) = SurveyVersion(0, version, survey)
     }
 }

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/repository/AnswerRepository.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/repository/AnswerRepository.kt
@@ -1,7 +1,6 @@
 package com.onboarding.form.repository
 
-import com.onboarding.form.domain.Survey
+import com.onboarding.form.domain.Answer
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface SurveyRepository : JpaRepository<Survey,Long> {
-}
+interface AnswerRepository : JpaRepository<Answer, Long>

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/repository/SurveyVersionRepository.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/repository/SurveyVersionRepository.kt
@@ -1,0 +1,20 @@
+package com.onboarding.form.repository
+
+import com.onboarding.form.domain.SurveyVersion
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface SurveyVersionRepository : JpaRepository<SurveyVersion, Long> {
+    @Query(
+        """
+        SELECT sv FROM SurveyVersion sv 
+        JOIN FETCH sv.questions 
+        WHERE sv.version = :version AND sv.survey.id = :surveyId
+        """
+    )
+    fun findBySurveyIdAndVersion(
+        @Param("surveyId") surveyId: Long,
+        @Param("version") version: Int,
+    ): SurveyVersion?
+}

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/request/CreateAnswerDto.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/request/CreateAnswerDto.kt
@@ -1,0 +1,38 @@
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.onboarding.form.domain.QuestionType
+
+
+data class CreateAnswerRequestDto(
+    val version: Int,
+    val answers: List<CreateAnswerDto>
+)
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "questionType",
+    visible = true
+)
+@JsonSubTypes(
+    JsonSubTypes.Type(name = QuestionType.SHORT_VALUE, value = CreateInsertAnswerDto::class),
+    JsonSubTypes.Type(name = QuestionType.LONG_VALUE, value = CreateInsertAnswerDto::class),
+    JsonSubTypes.Type(name = QuestionType.SINGLE_SELECT_VALUE, value = CreateSelectAnswerDto::class),
+    JsonSubTypes.Type(name = QuestionType.MULTI_SELECT_VALUE, value = CreateSelectAnswerDto::class),
+)
+sealed class CreateAnswerDto(
+    open val questionId: Long,
+    open val questionType: QuestionType,
+)
+
+data class CreateInsertAnswerDto(
+    override val questionId: Long,
+    override val questionType: QuestionType,
+    val content: String
+) : CreateAnswerDto(questionId, questionType)
+
+data class CreateSelectAnswerDto(
+    override val questionId: Long,
+    override val questionType: QuestionType,
+    val selected: List<String>
+) : CreateAnswerDto(questionId, questionType)

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/response/QuestionDto.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/response/QuestionDto.kt
@@ -3,6 +3,7 @@ package com.onboarding.form.response
 import com.onboarding.form.domain.*
 
 sealed class QuestionDto(
+    open val id: Long,
     open val title: String,
     open val description: String,
     open val type: QuestionType,
@@ -22,14 +23,16 @@ sealed class QuestionDto(
 }
 
 data class StandardQuestionDto(
+    override val id: Long,
     override val title: String,
     override val description: String,
     override val type: QuestionType,
     override val isRequired: Boolean
-) : QuestionDto(title, description, type, isRequired) {
+) : QuestionDto(id, title, description, type, isRequired) {
     companion object {
         fun of(question: ShortQuestion) =
             StandardQuestionDto(
+                question.id,
                 question.title,
                 question.description,
                 question.type,
@@ -38,6 +41,7 @@ data class StandardQuestionDto(
 
         fun of(question: LongQuestion) =
             StandardQuestionDto(
+                question.id,
                 question.title,
                 question.description,
                 question.type,
@@ -47,15 +51,17 @@ data class StandardQuestionDto(
 }
 
 data class SelectQuestionDto(
+    override val id: Long,
     override val title: String,
     override val description: String,
     override val type: QuestionType,
     override val isRequired: Boolean,
     val options: List<String>
-) : QuestionDto(title, description, type, isRequired) {
+) : QuestionDto(id, title, description, type, isRequired) {
     companion object {
         fun of(question: SingleSelectQuestion) =
             SelectQuestionDto(
+                question.id,
                 question.title,
                 question.description,
                 question.type,
@@ -65,6 +71,7 @@ data class SelectQuestionDto(
 
         fun of(question: MultiSelectQuestion) =
             SelectQuestionDto(
+                question.id,
                 question.title,
                 question.description,
                 question.type,

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/response/QuestionDto.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/response/QuestionDto.kt
@@ -11,36 +11,10 @@ sealed class QuestionDto(
     companion object {
         fun of(question: Question): QuestionDto {
             return when (question) {
-                is LongQuestion -> StandardQuestionDto(
-                    question.title,
-                    question.description,
-                    question.getType(),
-                    question.isRequired
-                )
-
-                is ShortQuestion -> StandardQuestionDto(
-                    question.title,
-                    question.description,
-                    question.getType(),
-                    question.isRequired
-                )
-
-                is MultiSelectQuestion -> SelectQuestionDto(
-                    question.title,
-                    question.description,
-                    question.getType(),
-                    question.isRequired,
-                    question.answerList
-                )
-
-                is SingleSelectQuestion -> SelectQuestionDto(
-                    question.title,
-                    question.description,
-                    question.getType(),
-                    question.isRequired,
-                    question.answerList
-                )
-
+                is LongQuestion -> StandardQuestionDto.of(question)
+                is ShortQuestion -> StandardQuestionDto.of(question)
+                is MultiSelectQuestion -> SelectQuestionDto.of(question)
+                is SingleSelectQuestion -> SelectQuestionDto.of(question)
                 else -> throw IllegalArgumentException("Invalid question type")
             }
         }
@@ -52,7 +26,25 @@ data class StandardQuestionDto(
     override val description: String,
     override val type: QuestionType,
     override val isRequired: Boolean
-) : QuestionDto(title, description, type, isRequired)
+) : QuestionDto(title, description, type, isRequired) {
+    companion object {
+        fun of(question: ShortQuestion) =
+            StandardQuestionDto(
+                question.title,
+                question.description,
+                question.type,
+                question.isRequired
+            )
+
+        fun of(question: LongQuestion) =
+            StandardQuestionDto(
+                question.title,
+                question.description,
+                question.type,
+                question.isRequired
+            )
+    }
+}
 
 data class SelectQuestionDto(
     override val title: String,
@@ -60,4 +52,24 @@ data class SelectQuestionDto(
     override val type: QuestionType,
     override val isRequired: Boolean,
     val options: List<String>
-) : QuestionDto(title, description, type, isRequired)
+) : QuestionDto(title, description, type, isRequired) {
+    companion object {
+        fun of(question: SingleSelectQuestion) =
+            SelectQuestionDto(
+                question.title,
+                question.description,
+                question.type,
+                question.isRequired,
+                question.answerList
+            )
+
+        fun of(question: MultiSelectQuestion) =
+            SelectQuestionDto(
+                question.title,
+                question.description,
+                question.type,
+                question.isRequired,
+                question.answerList
+            )
+    }
+}

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/response/SurveyDto.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/response/SurveyDto.kt
@@ -8,14 +8,14 @@ data class SurveyDto(
     val version: Int,
     val title: String,
     val description: String,
-    val item: List<QuestionDto>
+    val questions: List<QuestionDto>
 ) {
 
     companion object {
         fun of(survey: Survey) =
             SurveyDto(
                 survey.id,
-                survey.currentVersion.version,
+                survey.getCurrentVersion().version,
                 survey.title,
                 survey.description,
                 survey.getQuestions().map(QuestionDto::of)

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/response/SurveyDto.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/response/SurveyDto.kt
@@ -12,17 +12,14 @@ data class SurveyDto(
 ) {
 
     companion object {
-        fun of(survey: Survey): SurveyDto {
-            return SurveyDto(
-                survey.id!!,
+        fun of(survey: Survey) =
+            SurveyDto(
+                survey.id,
                 survey.currentVersion.version,
                 survey.title,
                 survey.description,
-                survey.getQuestions().map {
-                    QuestionDto.of(it)
-                }.toList()
+                survey.getQuestions().map(QuestionDto::of)
             )
-        }
     }
 
 }

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/response/SurveyDto.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/response/SurveyDto.kt
@@ -1,12 +1,29 @@
 package com.onboarding.form.response
 
+import com.onboarding.form.domain.Survey
+
 
 data class SurveyDto(
     val id: Long,
+    val version: Int,
     val title: String,
     val description: String,
     val item: List<QuestionDto>
 ) {
+
+    companion object {
+        fun of(survey: Survey): SurveyDto {
+            return SurveyDto(
+                survey.id!!,
+                survey.currentVersion.version,
+                survey.title,
+                survey.description,
+                survey.getQuestions().map {
+                    QuestionDto.of(it)
+                }.toList()
+            )
+        }
+    }
 
 }
 

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/service/SurveyService.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/service/SurveyService.kt
@@ -1,8 +1,12 @@
 package com.onboarding.form.service
 
+import CreateAnswerRequestDto
+import com.onboarding.form.domain.Answer
 import com.onboarding.form.domain.Question
 import com.onboarding.form.domain.Survey
+import com.onboarding.form.repository.AnswerRepository
 import com.onboarding.form.repository.SurveyRepository
+import com.onboarding.form.repository.SurveyVersionRepository
 import com.onboarding.form.request.CreateSurveyDto
 import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
@@ -11,7 +15,9 @@ import org.springframework.stereotype.Service
 
 @Service
 class SurveyService(
-    private val surveyRepository: SurveyRepository
+    private val surveyRepository: SurveyRepository,
+    private val surveyVersionRepository: SurveyVersionRepository,
+    private val answerRepository: AnswerRepository,
 ) {
     fun createSurvey(surveyDto: CreateSurveyDto): Survey {
         val survey = Survey.of(
@@ -26,12 +32,26 @@ class SurveyService(
     }
 
     @Transactional
-    fun updateSurveyDto(id: Long, surveyDto: CreateSurveyDto): Survey {
+    fun updateSurvey(id: Long, surveyDto: CreateSurveyDto): Survey {
         val survey = requireNotNull(surveyRepository.findByIdOrNull(id)) { "Survey not found" }
 
         survey.update(surveyDto.title, surveyDto.description, surveyDto.questions.map { Question.of(it) }.toList())
 
         surveyRepository.save(survey)
         return survey
+    }
+
+    @Transactional
+    fun submitAnswer(surveyId: Long, answerRequestDto: CreateAnswerRequestDto) {
+        val surveyVersion =
+            requireNotNull(surveyVersionRepository.findBySurveyIdAndVersion(surveyId, answerRequestDto.version)) {
+                "Survey version not found"
+            }
+
+        val questionIdToResponse: Map<Long, Answer> =
+            answerRequestDto.answers.associate { it.questionId to Answer.of(it) }
+
+        surveyVersion.checkValid(questionIdToResponse)
+        answerRepository.saveAll(questionIdToResponse.values)
     }
 }

--- a/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/service/SurveyService.kt
+++ b/project/wonjun-onboarding/src/main/kotlin/com/onboarding/form/service/SurveyService.kt
@@ -14,7 +14,7 @@ class SurveyService(
     private val surveyRepository: SurveyRepository
 ) {
     fun createSurvey(surveyDto: CreateSurveyDto): Survey {
-        val survey = Survey(
+        val survey = Survey.of(
             title = surveyDto.title,
             description = surveyDto.description,
         )

--- a/project/wonjun-onboarding/src/test/kotlin/com/onboarding/form/controller/SurveyControllerTest.kt
+++ b/project/wonjun-onboarding/src/test/kotlin/com/onboarding/form/controller/SurveyControllerTest.kt
@@ -19,32 +19,33 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @SpringBootTest
 @AutoConfigureMockMvc
-class SurveyControllerTest{
+class SurveyControllerTest {
     @Autowired
     lateinit var mockMvc: MockMvc
+
     @Autowired
     lateinit var objectMapper: ObjectMapper
 
     @Test
     @DisplayName("Controller 요청시 성공 응답이 내려오는지 테스트")
-    fun createSurvey(){
+    fun createSurvey() {
         val createSurveyDto = CreateSurveyDto(
             title = "testTitle",
             description = "testDescription",
-            questions =  listOf(
+            questions = listOf(
                 CreateSelectQuestionDto(
                     title = "testTitle",
                     description = "testDescription",
                     type = QuestionType.MULTI_SELECT,
                     isRequired = true,
-                    answerList =  listOf("testAnswer1", "testAnswer2")
+                    answerList = listOf("testAnswer1", "testAnswer2")
                 ),
                 CreateSelectQuestionDto(
                     title = "testTitle",
                     description = "testDescription",
                     type = QuestionType.SINGLE_SELECT,
                     isRequired = true,
-                    answerList =  listOf("testAnswer1", "testAnswer2")
+                    answerList = listOf("testAnswer1", "testAnswer2")
                 ),
                 CreateStandardQuestionDto(
                     title = "testTitle",
@@ -74,16 +75,18 @@ class SurveyControllerTest{
 
     @Test
     @DisplayName("Survey에 Question을 10개이상 입력한 경우 에러 응답이 정상적으로 내려오는지 테스트")
-    fun createSurveyFail(){
+    fun createSurveyFail() {
         val createSurveyDto = CreateSurveyDto(
             title = "testTitle",
             description = "testDescription",
-            questions = (0 until 11).map { CreateStandardQuestionDto(
-                title = "testTitle",
-                description = "testDescription",
-                type = QuestionType.LONG,
-                isRequired = true,
-            ) }.toList()
+            questions = (0 until 11).map {
+                CreateStandardQuestionDto(
+                    title = "testTitle",
+                    description = "testDescription",
+                    type = QuestionType.LONG,
+                    isRequired = true,
+                )
+            }.toList()
         )
 
         mockMvc.perform(

--- a/project/wonjun-onboarding/src/test/kotlin/com/onboarding/form/domain/SurveyTest.kt
+++ b/project/wonjun-onboarding/src/test/kotlin/com/onboarding/form/domain/SurveyTest.kt
@@ -31,9 +31,9 @@ class SurveyTest {
         val question = ShortQuestion(title = "test", description = "test", isRequired = true)
         survey.addQuestion(question)
 
-        assertEquals(survey.currentVersion.version, 1)
+        assertEquals(survey.currentVersion.version, 0)
 
         survey.update("newTitle", "newDescription", listOf(question))
-        assertEquals(survey.currentVersion.version, 2)
+        assertEquals(survey.currentVersion.version, 1)
     }
 }

--- a/project/wonjun-onboarding/src/test/kotlin/com/onboarding/form/domain/SurveyTest.kt
+++ b/project/wonjun-onboarding/src/test/kotlin/com/onboarding/form/domain/SurveyTest.kt
@@ -3,6 +3,7 @@ package com.onboarding.form.domain
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
 
 
 class SurveyTest {
@@ -18,5 +19,21 @@ class SurveyTest {
         repeat(10) { survey.addQuestion(question) }
 
         assertThrows<IllegalStateException> { survey.addQuestion(question) }
+    }
+
+    @Test
+    @DisplayName("설문조사를 수정할 경우 version 값이 1씩 증가한다")
+    fun increaseSequenceWhenSurveyUpdated() {
+        val survey = Survey.of(
+            title = "test",
+            description = "test"
+        )
+        val question = ShortQuestion(title = "test", description = "test", isRequired = true)
+        survey.addQuestion(question)
+
+        assertEquals(survey.currentVersion.version, 1)
+
+        survey.update("newTitle", "newDescription", listOf(question))
+        assertEquals(survey.currentVersion.version, 2)
     }
 }

--- a/project/wonjun-onboarding/src/test/kotlin/com/onboarding/form/domain/SurveyTest.kt
+++ b/project/wonjun-onboarding/src/test/kotlin/com/onboarding/form/domain/SurveyTest.kt
@@ -31,9 +31,9 @@ class SurveyTest {
         val question = ShortQuestion(title = "test", description = "test", isRequired = true)
         survey.addQuestion(question)
 
-        assertEquals(survey.currentVersion.version, 0)
+        assertEquals(0, survey.getCurrentVersion().version)
 
         survey.update("newTitle", "newDescription", listOf(question))
-        assertEquals(survey.currentVersion.version, 1)
+        assertEquals(1, survey.getCurrentVersion().version)
     }
 }

--- a/project/wonjun-onboarding/src/test/kotlin/com/onboarding/form/domain/SurveyTest.kt
+++ b/project/wonjun-onboarding/src/test/kotlin/com/onboarding/form/domain/SurveyTest.kt
@@ -9,7 +9,7 @@ class SurveyTest {
     @Test
     @DisplayName("설문조사는 10개 이상의 질문을 가지지 못한다.")
     fun surveysCanNotHaveExceedNumberOfQuestions() {
-        val survey = Survey(
+        val survey = Survey.of(
             title = "test",
             description = "test"
         )

--- a/project/wonjun-onboarding/src/test/kotlin/com/onboarding/form/service/SurveyServiceTest.kt
+++ b/project/wonjun-onboarding/src/test/kotlin/com/onboarding/form/service/SurveyServiceTest.kt
@@ -63,7 +63,7 @@ class SurveyServiceTest {
         (actualSurvey.getQuestions().zip(createSurveyDto.questions)).forEach {
             assertEquals(it.first.title, it.second.title)
             assertEquals(it.first.description, it.second.description)
-            assertEquals(it.first.getType(), it.second.type)
+            assertEquals(it.first.type, it.second.type)
             assertEquals(it.first.isRequired, it.second.isRequired)
 
             if (it.first is MultiSelectQuestion) {
@@ -183,7 +183,7 @@ class SurveyServiceTest {
             )
         )
 
-        val updateActualSurvey = surveyService.updateSurveyDto(actualSurvey.id!!, updateSurveyDto)
+        val updateActualSurvey = surveyService.updateSurveyDto(actualSurvey.id, updateSurveyDto)
 
         assertEquals(updateActualSurvey.title, updateSurveyDto.title)
         assertEquals(updateActualSurvey.description, updateSurveyDto.description)
@@ -191,7 +191,7 @@ class SurveyServiceTest {
         (updateActualSurvey.getQuestions().zip(updateSurveyDto.questions)).forEach {
             assertEquals(it.first.title, it.second.title)
             assertEquals(it.first.description, it.second.description)
-            assertEquals(it.first.getType(), it.second.type)
+            assertEquals(it.first.type, it.second.type)
             assertEquals(it.first.isRequired, it.second.isRequired)
 
             if (it.first is MultiSelectQuestion) {
@@ -233,7 +233,7 @@ class SurveyServiceTest {
 
         val survey = surveyService.createSurvey(createSurveyDto)
 
-        assertEquals(survey.currentVersion.version, 1)
+        assertEquals(survey.currentVersion.version, 0)
 
         val updateSurveyDto = CreateSurveyDto(
             title = "testTitle2",
@@ -249,10 +249,10 @@ class SurveyServiceTest {
             )
         )
 
-        val updateActualSurvey = surveyService.updateSurveyDto(survey.id!!, updateSurveyDto)
+        val updateActualSurvey = surveyService.updateSurveyDto(survey.id, updateSurveyDto)
 
         assertEquals(updateActualSurvey.title, updateSurveyDto.title)
         assertEquals(updateActualSurvey.description, updateSurveyDto.description)
-        assertEquals(updateActualSurvey.currentVersion.version, 2)
+        assertEquals(updateActualSurvey.currentVersion.version, 1)
     }
 }

--- a/project/wonjun-onboarding/src/test/kotlin/com/onboarding/form/service/SurveyServiceTest.kt
+++ b/project/wonjun-onboarding/src/test/kotlin/com/onboarding/form/service/SurveyServiceTest.kt
@@ -85,6 +85,7 @@ class SurveyServiceTest {
             }
         }
     }
+
     @Test
     @DisplayName("Survey가 존재하지 않는데 수정을 시도할 시 에러가 발생한다.")
     fun updateSurveyTestSurveyIsNotExist() {
@@ -103,7 +104,7 @@ class SurveyServiceTest {
         )
 
 
-        assertThrows<IllegalArgumentException>{
+        assertThrows<IllegalArgumentException> {
             surveyService.updateSurveyDto(1, updateSurveyDto)
         }
     }
@@ -211,5 +212,47 @@ class SurveyServiceTest {
                 }
             }
         }
+    }
+
+    @Test
+    @DisplayName("설문조사 수정 시 새로운 버전이 추가된다.")
+    fun updateSurveyVersionTest() {
+        val createSurveyDto = CreateSurveyDto(
+            title = "testTitle",
+            description = "testDescription",
+            questions = listOf(
+                CreateSelectQuestionDto(
+                    title = "testTitle",
+                    description = "testDescription",
+                    type = QuestionType.MULTI_SELECT,
+                    isRequired = true,
+                    answerList = listOf("testAnswer1", "testAnswer2")
+                ),
+            )
+        )
+
+        val survey = surveyService.createSurvey(createSurveyDto)
+
+        assertEquals(survey.currentVersion.version, 1)
+
+        val updateSurveyDto = CreateSurveyDto(
+            title = "testTitle2",
+            description = "testDescription2",
+            questions = listOf(
+                CreateSelectQuestionDto(
+                    title = "testTitle2",
+                    description = "testDescription2",
+                    type = QuestionType.MULTI_SELECT,
+                    isRequired = true,
+                    answerList = listOf("testAnswer12", "testAnswer22")
+                )
+            )
+        )
+
+        val updateActualSurvey = surveyService.updateSurveyDto(survey.id!!, updateSurveyDto)
+
+        assertEquals(updateActualSurvey.title, updateSurveyDto.title)
+        assertEquals(updateActualSurvey.description, updateSurveyDto.description)
+        assertEquals(updateActualSurvey.currentVersion.version, 2)
     }
 }

--- a/project/wonjun-onboarding/src/test/kotlin/com/onboarding/form/service/SurveyServiceTest.kt
+++ b/project/wonjun-onboarding/src/test/kotlin/com/onboarding/form/service/SurveyServiceTest.kt
@@ -9,6 +9,7 @@ import com.onboarding.form.request.CreateSurveyDto
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import kotlin.test.Test
@@ -60,6 +61,133 @@ class SurveyServiceTest {
         assertEquals(actualSurvey.description, createSurveyDto.description)
 
         (actualSurvey.questions.zip(createSurveyDto.questions)).forEach {
+            assertEquals(it.first.title, it.second.title)
+            assertEquals(it.first.description, it.second.description)
+            assertEquals(it.first.getType(), it.second.type)
+            assertEquals(it.first.isRequired, it.second.isRequired)
+
+            if (it.first is MultiSelectQuestion) {
+                val selectQuestion = it.first as MultiSelectQuestion
+                assertTrue(it.second is CreateSelectQuestionDto)
+                val selectQuestionDto = it.second as CreateSelectQuestionDto
+                selectQuestion.answerList.zip(selectQuestionDto.answerList).forEach {
+                    assertEquals(it.first, it.second)
+                }
+            }
+
+            if (it.first is SingleSelectQuestion) {
+                val selectQuestion = it.first as SingleSelectQuestion
+                assertTrue(it.second is CreateSelectQuestionDto)
+                val selectQuestionDto = it.second as CreateSelectQuestionDto
+                selectQuestion.answerList.zip(selectQuestionDto.answerList).forEach {
+                    assertEquals(it.first, it.second)
+                }
+            }
+        }
+    }
+    @Test
+    @DisplayName("Survey가 존재하지 않는데 수정을 시도할 시 에러가 발생한다.")
+    fun updateSurveyTestSurveyIsNotExist() {
+        val updateSurveyDto = CreateSurveyDto(
+            title = "testTitle",
+            description = "testDescription",
+            questions = listOf(
+                CreateSelectQuestionDto(
+                    title = "testTitle",
+                    description = "testDescription",
+                    type = QuestionType.MULTI_SELECT,
+                    isRequired = true,
+                    answerList = listOf("testAnswer1", "testAnswer2")
+                ),
+            )
+        )
+
+
+        assertThrows<IllegalArgumentException>{
+            surveyService.updateSurveyDto(1, updateSurveyDto)
+        }
+    }
+
+    @Test
+    @DisplayName("네가지 질문 타입에 맞춰서 설문조사를 수정할 수 있다.")
+    fun updateSurveyTest() {
+        val createSurveyDto = CreateSurveyDto(
+            title = "testTitle",
+            description = "testDescription",
+            questions = listOf(
+                CreateSelectQuestionDto(
+                    title = "testTitle",
+                    description = "testDescription",
+                    type = QuestionType.MULTI_SELECT,
+                    isRequired = true,
+                    answerList = listOf("testAnswer1", "testAnswer2")
+                ),
+                CreateSelectQuestionDto(
+                    title = "testTitle",
+                    description = "testDescription",
+                    type = QuestionType.SINGLE_SELECT,
+                    isRequired = true,
+                    answerList = listOf("testAnswer1", "testAnswer2")
+                ),
+                CreateStandardQuestionDto(
+                    title = "testTitle",
+                    description = "testDescription",
+                    type = QuestionType.SHORT,
+                    isRequired = true,
+                ),
+                CreateStandardQuestionDto(
+                    title = "testTitle",
+                    description = "testDescription",
+                    type = QuestionType.LONG,
+                    isRequired = true,
+                )
+            )
+        )
+
+        val actualSurvey = surveyService.createSurvey(createSurveyDto)
+
+        assertEquals(actualSurvey.title, createSurveyDto.title)
+        assertEquals(actualSurvey.description, createSurveyDto.description)
+
+        val updateSurveyDto = CreateSurveyDto(
+            title = "testTitle2",
+            description = "testDescription2",
+            questions = listOf(
+                CreateSelectQuestionDto(
+                    title = "testTitle2",
+                    description = "testDescription2",
+                    type = QuestionType.MULTI_SELECT,
+                    isRequired = true,
+                    answerList = listOf("testAnswer12", "testAnswer22")
+                ),
+                CreateSelectQuestionDto(
+                    title = "testTitle2",
+                    description = "testDescription2",
+                    type = QuestionType.SINGLE_SELECT,
+                    isRequired = true,
+                    answerList = listOf("testAnswer12", "testAnswer22")
+                ),
+                CreateStandardQuestionDto(
+                    title = "testTitle2",
+                    description = "testDescription2",
+                    type = QuestionType.SHORT,
+                    isRequired = true,
+                ),
+                CreateStandardQuestionDto(
+                    title = "testTitle2",
+                    description = "testDescription2",
+                    type = QuestionType.LONG,
+                    isRequired = true,
+                )
+            )
+        )
+
+        val updateActualSurvey = surveyService.updateSurveyDto(actualSurvey.id!!, updateSurveyDto)
+
+        assertEquals(updateActualSurvey.title, updateSurveyDto.title)
+        assertEquals(updateActualSurvey.description, updateSurveyDto.description)
+
+        (updateActualSurvey.questions.zip(updateSurveyDto.questions)).forEach {
             assertEquals(it.first.title, it.second.title)
             assertEquals(it.first.description, it.second.description)
             assertEquals(it.first.getType(), it.second.type)

--- a/project/wonjun-onboarding/src/test/kotlin/com/onboarding/form/service/SurveyServiceTest.kt
+++ b/project/wonjun-onboarding/src/test/kotlin/com/onboarding/form/service/SurveyServiceTest.kt
@@ -60,7 +60,7 @@ class SurveyServiceTest {
         assertEquals(actualSurvey.title, createSurveyDto.title)
         assertEquals(actualSurvey.description, createSurveyDto.description)
 
-        (actualSurvey.questions.zip(createSurveyDto.questions)).forEach {
+        (actualSurvey.getQuestions().zip(createSurveyDto.questions)).forEach {
             assertEquals(it.first.title, it.second.title)
             assertEquals(it.first.description, it.second.description)
             assertEquals(it.first.getType(), it.second.type)
@@ -187,7 +187,7 @@ class SurveyServiceTest {
         assertEquals(updateActualSurvey.title, updateSurveyDto.title)
         assertEquals(updateActualSurvey.description, updateSurveyDto.description)
 
-        (updateActualSurvey.questions.zip(updateSurveyDto.questions)).forEach {
+        (updateActualSurvey.getQuestions().zip(updateSurveyDto.questions)).forEach {
             assertEquals(it.first.title, it.second.title)
             assertEquals(it.first.description, it.second.description)
             assertEquals(it.first.getType(), it.second.type)


### PR DESCRIPTION
## Goal

설문조사 응답을 제출 할 수 있도록 합니다.

## Changes

Survey에 Version을 추가하여 Version 별로 Question과 Answer들을 관리할 수 있게 했습니다
각각의 Question들 마다 Answer들을 Validation 을 할 수 있도록 수정하였습니다.


