### PR TITLE
설문조사 조회 api 구현

### DIFF
--- a/project/seonghun-onboarding/README.md
+++ b/project/seonghun-onboarding/README.md
@@ -77,6 +77,47 @@ item : {
 </div>
 </details>
 
+<details>
+<summary>설문조사 조회 api</summary>
+<div markdown="1">
+
+| Http Method | Path           |
+|-------------|----------------|
+| GET         | /surveys       |
+
+- Request
+
+없음
+
+- Response
+
+```
+{
+    "status": 200,
+    "result": [
+        {
+            "id": Long,
+            "name": String,
+            "description": String,
+            "items": [
+                {
+                    "id": Long,
+                    name: String,
+                    description : String,
+                    type: ItemType,
+                    contents: List<String>
+                }
+            ]
+        }...
+    ]
+}
+
+```
+
+
+</div>
+</details>
+
 ### 설문조사 응답
 
 

--- a/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/controller/SurveyController.kt
+++ b/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/controller/SurveyController.kt
@@ -8,6 +8,7 @@ import com.chosseang.seonghunonboarding.entity.Survey
 import com.chosseang.seonghunonboarding.service.SurveyService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -17,6 +18,12 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/surveys")
 class SurveyController (val surveyService: SurveyService) {
+
+    @GetMapping
+    fun searchSurveys() : List<Survey> {
+
+        return surveyService.searchSurvey();
+    }
 
     @PostMapping("/create")
     @ResponseBody

--- a/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/controller/SurveyController.kt
+++ b/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/controller/SurveyController.kt
@@ -3,6 +3,7 @@ package com.chosseang.seonghunonboarding.controller
 import com.chosseang.seonghunonboarding.dto.ApiResponse
 import com.chosseang.seonghunonboarding.dto.SurveyCreateRequest
 import com.chosseang.seonghunonboarding.dto.SurveyCreateResponse
+import com.chosseang.seonghunonboarding.dto.SurveySearchResponse
 import com.chosseang.seonghunonboarding.entity.Item
 import com.chosseang.seonghunonboarding.entity.Survey
 import com.chosseang.seonghunonboarding.service.SurveyService
@@ -20,9 +21,21 @@ import org.springframework.web.bind.annotation.RestController
 class SurveyController (val surveyService: SurveyService) {
 
     @GetMapping
-    fun searchSurveys() : List<Survey> {
+    fun searchSurveys() : ResponseEntity<ApiResponse<List<SurveySearchResponse>>> {
 
-        return surveyService.searchSurvey();
+        val apiResponse = ApiResponse(
+            status = HttpStatus.OK.value(),
+            result = surveyService.searchSurvey().map {
+                survey -> SurveySearchResponse(
+                    id = survey.id,
+                    name = survey.name,
+                    description = survey.description,
+                    items = survey.items
+                )
+            }
+        )
+
+        return ResponseEntity.ok(apiResponse)
     }
 
     @PostMapping("/create")

--- a/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/dto/SurveyProtocols.kt
+++ b/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/dto/SurveyProtocols.kt
@@ -33,3 +33,10 @@ data class ItemResponse(
     val type: String,
     val contents: List<String>
 )
+
+data class SurveySearchResponse(
+    val id: Long?,
+    val name : String,
+    val description: String,
+    val items: List<Item>
+)

--- a/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/service/SurveyService.kt
+++ b/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/service/SurveyService.kt
@@ -33,4 +33,8 @@ class SurveyService(val repository: SurveyRepository) {
             )
         }
     }
+
+    fun searchSurvey(): List<Survey> {
+        return repository.findAll()
+    }
 }


### PR DESCRIPTION
## Goal

설문조사 조회 api 기능 구현하였습니다.

## Changes

- 도메인 추가
  - SurveyController
  - SurveyService
- DTO 추가
  - SurveyProtocols
- api 상세 명세서 추가
  - README

## Description

설문조사 조회하는 기능을 구현하였습니다.(추가기능)
전체 설문조사를 조사하는 기능이고 설문조사 응답 제출을 위해서는 기존 제출한 설문조사의 id값이 필요하다 생각하여 해당 api 추가하였습니다.

