### PR TITLE
설문조사 생성 시 설문조사 테이블에 2개가 저장되는 버그 수정

### DIFF
--- a/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/service/SurveyService.kt
+++ b/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/service/SurveyService.kt
@@ -12,20 +12,18 @@ class SurveyService(val repository: SurveyRepository) {
 
     @Transactional
     fun createSurvey(surveyCreateRequest: SurveyCreateRequest): SurveyCreateResponse {
-        // 각 아이템의 survey 참조 설정 (양방향 관계 유지)
-        surveyCreateRequest.items.forEach { item ->
-            item.survey = Survey(
-                name = surveyCreateRequest.name,
-                description = surveyCreateRequest.description,
-                items = surveyCreateRequest.items.toMutableList()
-            )
-        }
 
-        return repository.save(Survey(
+        val survey = Survey(
             name = surveyCreateRequest.name,
             description = surveyCreateRequest.description,
-            items = surveyCreateRequest.items.toMutableList()
-        )).let {
+            items = mutableListOf() // 빈 리스트로 시작
+        )
+
+        // Survey 엔티티에 구현된 메서드를 사용하여 아이템 추가
+        survey.addItems(surveyCreateRequest.items)
+
+        // 저장 후 응답 변환
+        return repository.save(survey).let {
             SurveyCreateResponse(
                 name = it.name,
                 description = it.description,


### PR DESCRIPTION
## Goal

설문조사 생성 기능에 버그가 있어 수정하였습니다.

## Changes

- 버그 수정
  - SurveyService

## Description

설문조사 생성을 1번만 했는데 테이블에 2개가 생성되는 버그가 발생하여 수정하였습니다
제가 Service단에서 Survey 객체를 2번 생성하여 해당 문제가 발생하는 것으로 판단하였습니다.
