### PR TITLE
설문조사 수정 api 기능 구현

### DIFF
--- a/project/seonghun-onboarding/README.md
+++ b/project/seonghun-onboarding/README.md
@@ -77,6 +77,91 @@ item : {
 </div>
 </details>
 
+<details>
+<summary>설문조사 조회 api</summary>
+<div markdown="1">
+
+| Http Method | Path           |
+|-------------|----------------|
+| GET         | /surveys       |
+
+- Request
+
+없음
+
+- Response
+
+```
+{
+    "status": 200,
+    "result": [
+        {
+            "id": Long,
+            "name": String,
+            "description": String,
+            "items": [
+                {
+                    "id": Long,
+                    name: String,
+                    description : String,
+                    type: ItemType,
+                    contents: List<String>
+                }
+            ]
+        }...
+    ]
+}
+
+```
+
+
+</div>
+</details>
+
+<details>
+<summary>설문조사 수정 api</summary>
+<div markdown="1">
+
+| Http Method | Path                 |
+|------------|----------------------|
+| PATCH      | /surveys/update/{id} |
+
+- Request
+
+| Param       | Type     | Description   |
+|-------------|----------|---------------|
+| name        | String   | 수정할 설문이름      |
+| description | String   | 수정할 설문 설명     |
+| items       | List<item> | 수정할 질문 항목들 배열 |
+
+- Response
+
+```
+{
+    "status": 200,
+    "result": 
+        {
+            "id": Long,
+            "name": String,
+            "description": String,
+            "items": [
+                {
+                    "id": Long,
+                    name: String,
+                    description : String,
+                    type: ItemType,
+                    contents: List<String>
+                }
+            ]
+        }
+}
+
+```
+
+
+</div>
+</details>
+
 ### 설문조사 응답
 
 

--- a/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/controller/SurveyController.kt
+++ b/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/controller/SurveyController.kt
@@ -3,11 +3,14 @@ package com.chosseang.seonghunonboarding.controller
 import com.chosseang.seonghunonboarding.dto.ApiResponse
 import com.chosseang.seonghunonboarding.dto.SurveyCreateRequest
 import com.chosseang.seonghunonboarding.dto.SurveyCreateResponse
+import com.chosseang.seonghunonboarding.dto.SurveySearchResponse
 import com.chosseang.seonghunonboarding.entity.Item
 import com.chosseang.seonghunonboarding.entity.Survey
 import com.chosseang.seonghunonboarding.service.SurveyService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -17,6 +20,24 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/surveys")
 class SurveyController (val surveyService: SurveyService) {
+
+    @GetMapping
+    fun searchSurveys() : ResponseEntity<ApiResponse<List<SurveySearchResponse>>> {
+
+        val apiResponse = ApiResponse(
+            status = HttpStatus.OK.value(),
+            result = surveyService.searchSurvey().map {
+                survey -> SurveySearchResponse(
+                    id = survey.id,
+                    name = survey.name,
+                    description = survey.description,
+                    items = survey.items
+                )
+            }
+        )
+
+        return ResponseEntity.ok(apiResponse)
+    }
 
     @PostMapping("/create")
     @ResponseBody
@@ -51,5 +72,11 @@ class SurveyController (val surveyService: SurveyService) {
         )
 
         return ResponseEntity.ok(apiResponse)
+    }
+
+    @PatchMapping("/update")
+    @ResponseBody
+    fun updateSurvey(@RequestBody survey: Survey) : Survey? {
+        return surveyService.updateSurvey(survey)
     }
 }

--- a/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/controller/SurveyController.kt
+++ b/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/controller/SurveyController.kt
@@ -3,13 +3,11 @@ package com.chosseang.seonghunonboarding.controller
 import com.chosseang.seonghunonboarding.dto.ApiResponse
 import com.chosseang.seonghunonboarding.dto.SurveyCreateRequest
 import com.chosseang.seonghunonboarding.dto.SurveyCreateResponse
-import com.chosseang.seonghunonboarding.dto.SurveySearchResponse
 import com.chosseang.seonghunonboarding.entity.Item
 import com.chosseang.seonghunonboarding.entity.Survey
 import com.chosseang.seonghunonboarding.service.SurveyService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -20,24 +18,6 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/surveys")
 class SurveyController (val surveyService: SurveyService) {
-
-    @GetMapping
-    fun searchSurveys() : ResponseEntity<ApiResponse<List<SurveySearchResponse>>> {
-
-        val apiResponse = ApiResponse(
-            status = HttpStatus.OK.value(),
-            result = surveyService.searchSurvey().map {
-                survey -> SurveySearchResponse(
-                    id = survey.id,
-                    name = survey.name,
-                    description = survey.description,
-                    items = survey.items
-                )
-            }
-        )
-
-        return ResponseEntity.ok(apiResponse)
-    }
 
     @PostMapping("/create")
     @ResponseBody

--- a/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/entity/Item.kt
+++ b/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/entity/Item.kt
@@ -27,13 +27,13 @@ data class Item(
     @JoinColumn(name = "survey_id")
     var survey: Survey? = null,
 
-    val name: String,
-    val description: String,
+    var name: String,
+    var description: String,
 
     @Enumerated(EnumType.STRING)
     val type: ItemType,
 
     @ElementCollection
     @CollectionTable(name = "item_contents", joinColumns = [JoinColumn(name = "itemId")])
-    val contents: List<String>
+    var contents: List<String>
 )

--- a/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/entity/Survey.kt
+++ b/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/entity/Survey.kt
@@ -15,7 +15,7 @@ data class Survey(
     var name: String,
     var description: String,
 
-    @OneToMany(mappedBy = "survey", orphanRemoval = true, cascade = [CascadeType.ALL])
+    @OneToMany(mappedBy = "survey", cascade = [CascadeType.ALL])
     var items: MutableList<Item>
 ){
     // 아이템 추가 메서드 - 양방향 관계 유지

--- a/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/entity/Survey.kt
+++ b/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/entity/Survey.kt
@@ -12,8 +12,8 @@ data class Survey(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
-    val name: String,
-    val description: String,
+    var name: String,
+    var description: String,
 
     @OneToMany(mappedBy = "survey", orphanRemoval = true, cascade = [CascadeType.ALL])
     var items: MutableList<Item>

--- a/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/service/SurveyService.kt
+++ b/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/service/SurveyService.kt
@@ -2,8 +2,11 @@ package com.chosseang.seonghunonboarding.service
 
 import com.chosseang.seonghunonboarding.dto.SurveyCreateRequest
 import com.chosseang.seonghunonboarding.dto.SurveyCreateResponse
+import com.chosseang.seonghunonboarding.entity.Item
 import com.chosseang.seonghunonboarding.entity.Survey
+import com.chosseang.seonghunonboarding.enum.ItemType
 import com.chosseang.seonghunonboarding.repository.SurveyRepository
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -12,25 +15,75 @@ class SurveyService(val repository: SurveyRepository) {
 
     @Transactional
     fun createSurvey(surveyCreateRequest: SurveyCreateRequest): SurveyCreateResponse {
-        // 각 아이템의 survey 참조 설정 (양방향 관계 유지)
-        surveyCreateRequest.items.forEach { item ->
-            item.survey = Survey(
-                name = surveyCreateRequest.name,
-                description = surveyCreateRequest.description,
-                items = surveyCreateRequest.items.toMutableList()
-            )
-        }
 
-        return repository.save(Survey(
+        val survey = Survey(
             name = surveyCreateRequest.name,
             description = surveyCreateRequest.description,
-            items = surveyCreateRequest.items.toMutableList()
-        )).let {
+            items = mutableListOf() // 빈 리스트로 시작
+        )
+
+        // Survey 엔티티에 구현된 메서드를 사용하여 아이템 추가
+        survey.addItems(surveyCreateRequest.items)
+
+        // 저장 후 응답 변환
+        return repository.save(survey).let {
             SurveyCreateResponse(
                 name = it.name,
                 description = it.description,
                 items = it.items.toMutableList()
             )
         }
+    }
+
+    fun searchSurvey(): List<Survey> {
+        return repository.findAll()
+    }
+
+    @Transactional
+    fun updateSurvey(survey: Survey): Survey? {
+        val findSurvey = repository.findByIdOrNull(survey.id!!)
+
+        if (survey.name.isNotBlank()) {
+            findSurvey?.name = survey.name
+        }
+
+        if (survey.description.isNotBlank()) {
+            findSurvey?.description = survey.description
+        }
+
+        survey.items?.let { itemRequests ->
+            // 기존 아이템들 맵으로 변환
+            val existingItemsMap = findSurvey?.items?.associateBy { it.id }
+
+            // 요청에 없는 아이템 모두 제거 (orphanRemoval이 처리함)
+            val requestItemIds = itemRequests.mapNotNull { it.id }.toSet()
+            findSurvey?.items?.removeIf { it.id != null && it.id !in requestItemIds }
+
+            // 업데이트하거나 새로 추가
+            itemRequests.forEach { itemRequest ->
+                if (existingItemsMap != null) {
+                    if (itemRequest.id != null && existingItemsMap.containsKey(itemRequest.id)) {
+                        // 기존 아이템 업데이트
+                        val item = existingItemsMap[itemRequest.id]!!
+                        itemRequest.name?.let { item.name = it }
+                        itemRequest.description?.let { item.description = it }
+                        itemRequest.type?.let { /* type은 val이라 업데이트 불가 */ }
+                        itemRequest.contents?.let { item.contents = it }
+                    } else {
+                        // 새 아이템 추가
+                        val newItem = Item(
+                            id = null,
+                            name = itemRequest.name ?: "",
+                            description = itemRequest.description ?: "",
+                            type = itemRequest.type ?: ItemType.ShortAnswer,
+                            contents = itemRequest.contents ?: emptyList(),
+                            survey = findSurvey
+                        )
+                        findSurvey?.addItem(newItem)
+                    }
+                }
+            }
+        }
+        return findSurvey
     }
 }


### PR DESCRIPTION
## Goal

설문조사 수정 api 기능 구현을 위한 PR 입니다.

## Changes

- 도메인 추가
  - SurveyController
  - SurveyService
- entity 수정
  - Survey
  - Item
- api 상세 명세서
  - README

## Description

설문조사 수정 기능을 구현하였습니다.

items의 추가 및 수정도 가능하게 하였고 request에 넣지 않은 경우에는 기존의 값을 유지하게 하기 위해
PATCH 메소드로 통신 방식을 설정하였습니다.

