### PR TITLE
 설문조사 수정 API 추가

### DIFF
--- a/project/sangkyeong-onboarding/application/src/main/kotlin/org/survey/application/dto/command/UpdateSurveyCommand.kt
+++ b/project/sangkyeong-onboarding/application/src/main/kotlin/org/survey/application/dto/command/UpdateSurveyCommand.kt
@@ -1,0 +1,21 @@
+package org.survey.application.dto.command
+
+data class UpdateSurveyCommand(
+    val title: String,
+    val description: String,
+    val items: List<UpdateSurveyItemCommand>,
+)
+
+data class UpdateSurveyItemCommand(
+    val id: Long? = null,
+    val title: String,
+    val description: String,
+    val inputType: String,
+    val isRequired: Boolean,
+    val options: List<UpdateItemOptionCommand>? = null,
+)
+
+data class UpdateItemOptionCommand(
+    val id: Long? = null,
+    val value: String,
+)

--- a/project/sangkyeong-onboarding/application/src/main/kotlin/org/survey/application/usecase/survey/UpdateSurveyUseCase.kt
+++ b/project/sangkyeong-onboarding/application/src/main/kotlin/org/survey/application/usecase/survey/UpdateSurveyUseCase.kt
@@ -1,0 +1,106 @@
+package org.survey.application.usecase.survey
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.survey.application.dto.command.UpdateSurveyCommand
+import org.survey.application.dto.command.UpdateSurveyItemCommand
+import org.survey.domain.survey.model.SurveyItem
+import org.survey.domain.survey.service.SurveyCommandService
+import org.survey.domain.survey.service.SurveyQueryService
+
+@Service
+class UpdateSurveyUseCase(
+    private val surveyCommandService: SurveyCommandService,
+    private val surveyQueryService: SurveyQueryService,
+) {
+    @Transactional
+    fun execute(
+        surveyId: Long,
+        request: UpdateSurveyCommand,
+    ) {
+        /**
+         * 1. 설문조사 제목, 설명 업데이트
+         * 2. 기존 항목과 요청 항목 비교
+         * 3. 요청에 없는 기존 항목은 논리적 삭제
+         * 4. 새 항목 추가
+         * 5. 기존 항목 업데이트
+         * 6. 선택형 항목의 사용하지 않는 옵션 논리적 삭제 TODO
+         * 7. 선택형 항목 의 새 옵션 추가 TODO
+         * 8. 선택형 항목 의 기존 옵션 업데이트 TODO
+         */
+        surveyCommandService.updateSurvey(
+            surveyId = surveyId,
+            title = request.title,
+            description = request.description,
+        )
+
+        val existingItems = surveyQueryService.getSurveyItems(surveyId)
+        surveyCommandService.deleteNotUsingSurveyItems(
+            existingItems,
+            request.items.mapNotNull { it.id }.toSet(),
+        )
+
+        val newItems = request.items.filter { it.id == null }
+        if (newItems.isNotEmpty()) {
+            surveyCommandService.addSurveyItems(
+                surveyId,
+                newItems.map { createNewSurveyItem(it, surveyId) },
+            )
+        }
+
+        val existingItemsToUpdate = request.items.filter { it.id != null }
+        if (existingItemsToUpdate.isNotEmpty()) {
+            surveyCommandService.updateSurveyItems(
+                existingItemsToUpdate.map { updateExistingSurveyItem(it, surveyId) },
+            )
+        }
+    }
+
+    private fun createNewSurveyItem(
+        item: UpdateSurveyItemCommand,
+        surveyId: Long,
+    ): SurveyItem {
+        return SurveyItem(
+            surveyId = surveyId,
+            title = item.title,
+            description = item.description,
+            inputType = item.inputType,
+            isRequired = item.isRequired,
+            options = processItemOptions(item),
+        )
+    }
+
+    private fun updateExistingSurveyItem(
+        item: UpdateSurveyItemCommand,
+        surveyId: Long,
+    ): SurveyItem {
+        return SurveyItem(
+            id = item.id!!,
+            surveyId = surveyId,
+            title = item.title,
+            description = item.description,
+            inputType = item.inputType,
+            isRequired = item.isRequired,
+            options = processItemOptions(item),
+        )
+    }
+
+    private fun processItemOptions(item: UpdateSurveyItemCommand): List<String> {
+        return if (item.inputType in listOf("SINGLE_CHOICE", "MULTIPLE_CHOICE")) {
+            validateItemOptions(item)
+            item.options!!.map { option -> option.value }
+        } else {
+            emptyList()
+        }
+    }
+
+    private fun validateItemOptions(item: UpdateSurveyItemCommand) {
+        val optionSize =
+            item.options?.size
+                ?: throw IllegalArgumentException("선택형 질문에는 최소 1개 이상의 선택지가 필요합니다.")
+
+        if (optionSize > 10) {
+            throw IllegalArgumentException("선택형 질문은 최대 10개까지 가능합니다.")
+        }
+    }
+}

--- a/project/sangkyeong-onboarding/domain/src/main/kotlin/org/survey/domain/dto/SurveyItemData.kt
+++ b/project/sangkyeong-onboarding/domain/src/main/kotlin/org/survey/domain/dto/SurveyItemData.kt
@@ -1,8 +1,9 @@
 package org.survey.domain.dto
 
 data class SurveyItemData(
+    val id: Long? = null,
     val title: String,
-    val description: String,
+    val description: String?,
     val inputType: String,
     val isRequired: Boolean,
     val options: List<String>? = null,

--- a/project/sangkyeong-onboarding/domain/src/main/kotlin/org/survey/domain/survey/model/ItemOption.kt
+++ b/project/sangkyeong-onboarding/domain/src/main/kotlin/org/survey/domain/survey/model/ItemOption.kt
@@ -3,5 +3,13 @@ package org.survey.domain.survey.model
 class ItemOption(
     val id: Long = 0,
     val surveyItemId: Long,
-    val value: String,
-)
+    var value: String,
+    var isDeleted: Boolean = false,
+) {
+    fun markAsDeleted() {
+        if (isDeleted) {
+            throw IllegalStateException("해당 옵션이 이미 삭제되었습니다.")
+        }
+        this.isDeleted = true
+    }
+}

--- a/project/sangkyeong-onboarding/domain/src/main/kotlin/org/survey/domain/survey/model/Survey.kt
+++ b/project/sangkyeong-onboarding/domain/src/main/kotlin/org/survey/domain/survey/model/Survey.kt
@@ -4,8 +4,16 @@ import java.time.LocalDateTime
 
 class Survey(
     val id: Long = 0,
-    val title: String,
-    val description: String,
+    var title: String,
+    var description: String,
     val createdAt: LocalDateTime = LocalDateTime.now(),
     val updatedAt: LocalDateTime = LocalDateTime.now(),
-)
+) {
+    fun update(
+        title: String,
+        description: String,
+    ) {
+        this.title = title
+        this.description = description
+    }
+}

--- a/project/sangkyeong-onboarding/domain/src/main/kotlin/org/survey/domain/survey/model/SurveyItem.kt
+++ b/project/sangkyeong-onboarding/domain/src/main/kotlin/org/survey/domain/survey/model/SurveyItem.kt
@@ -3,8 +3,29 @@ package org.survey.domain.survey.model
 class SurveyItem(
     val id: Long = 0,
     val surveyId: Long,
-    val title: String,
-    val description: String?,
-    val inputType: String,
-    val isRequired: Boolean,
-)
+    var title: String,
+    var description: String?,
+    var inputType: String,
+    var isRequired: Boolean,
+    var isDeleted: Boolean = false,
+    val options: List<String>? = null,
+) {
+    fun markAsDeleted() {
+        if (isDeleted) {
+            throw IllegalStateException("설문 항목이 이미 삭제되었습니다.")
+        }
+        this.isDeleted = true
+    }
+
+    fun update(
+        title: String,
+        description: String?,
+        inputType: String,
+        isRequired: Boolean,
+    ) {
+        this.title = title
+        this.description = description
+        this.inputType = inputType
+        this.isRequired = isRequired
+    }
+}

--- a/project/sangkyeong-onboarding/domain/src/main/kotlin/org/survey/domain/survey/repository/ItemOptionRepository.kt
+++ b/project/sangkyeong-onboarding/domain/src/main/kotlin/org/survey/domain/survey/repository/ItemOptionRepository.kt
@@ -7,5 +7,14 @@ interface ItemOptionRepository {
 
     fun saveAll(itemOptions: List<ItemOption>)
 
-    fun findBySurveyItemIdIn(itemIds: List<Long>): List<ItemOption>
+    fun findBySurveyItemsIdIn(itemIds: List<Long>): List<ItemOption>
+
+    fun saveOptions(
+        itemId: Long,
+        options: List<String>,
+    )
+
+    fun findAllById(optionIds: List<Long>): List<ItemOption>
+
+    fun deleteOptions(itemOptions: List<ItemOption>)
 }

--- a/project/sangkyeong-onboarding/domain/src/main/kotlin/org/survey/domain/survey/repository/SurveyItemRepository.kt
+++ b/project/sangkyeong-onboarding/domain/src/main/kotlin/org/survey/domain/survey/repository/SurveyItemRepository.kt
@@ -8,4 +8,10 @@ interface SurveyItemRepository {
     fun saveAll(surveyItems: List<SurveyItem>): List<SurveyItem>
 
     fun findBySurveyId(surveyId: Long): List<SurveyItem>
+
+    fun findAllById(surveyItemIds: List<Long>): List<SurveyItem>
+
+    fun deleteItems(surveyItems: List<SurveyItem>)
+
+    fun updateItems(surveyItems: List<SurveyItem>)
 }

--- a/project/sangkyeong-onboarding/domain/src/main/kotlin/org/survey/domain/survey/service/SurveyCommandService.kt
+++ b/project/sangkyeong-onboarding/domain/src/main/kotlin/org/survey/domain/survey/service/SurveyCommandService.kt
@@ -64,21 +64,106 @@ class SurveyCommandService(
 
     private fun validateSurveyItems(items: List<SurveyItemData>) {
         if (items.isEmpty()) {
-            throw IllegalArgumentException("설문 항목이 최소 1개 이상 필요하다.")
+            throw IllegalArgumentException("설문 항목이 최소 1개 이상 필요합니다.")
         }
 
         if (items.size > 10) {
-            throw IllegalArgumentException("설문 항목은 최대 10개까지 가능하다.")
+            throw IllegalArgumentException("설문 항목은 최대 10개까지 가능합니다.")
         }
 
         items.forEach { item ->
             if (item.inputType !in listOf("SINGLE_CHOICE", "MULTIPLE_CHOICE") && !item.options.isNullOrEmpty()) {
-                throw IllegalArgumentException("선택형 질문이 아니면 선택지가 없어야 한다.")
+                throw IllegalArgumentException("선택형 질문이 아니면 선택지가 없어야 합니다.")
             }
 
             if (item.inputType in listOf("SINGLE_CHOICE", "MULTIPLE_CHOICE") && item.options.isNullOrEmpty()) {
-                throw IllegalArgumentException("선택형 질문에는 최소 1개 이상의 선택지가 필요하다.")
+                throw IllegalArgumentException("선택형 질문에는 최소 1개 이상의 선택지가 필요합니다.")
             }
         }
+    }
+
+    fun updateSurvey(
+        surveyId: Long,
+        title: String,
+        description: String,
+    ) {
+        val survey =
+            surveyRepository.findById(surveyId)
+                ?: throw IllegalArgumentException("설문조사를 찾을 수 없습니다.")
+
+        survey.update(title, description)
+
+        surveyRepository.save(survey)
+    }
+
+    fun deleteNotUsingSurveyItems(
+        existingItems: List<SurveyItem>,
+        requestItemIds: Set<Long>,
+    ) {
+        val itemsToDelete =
+            existingItems
+                .filter { it.id !in requestItemIds }
+                .map { it.id }
+
+        val surveyItems = surveyItemRepository.findAllById(itemsToDelete)
+
+        surveyItems.forEach {
+            it.markAsDeleted()
+        }
+
+        surveyItemRepository.deleteItems(surveyItems)
+    }
+
+    fun addSurveyItems(
+        surveyId: Long,
+        newItems: List<SurveyItem>,
+        options: List<String>? = null,
+    ) {
+        val savedItems = surveyItemRepository.saveAll(newItems)
+
+        val itemOptionsMap = mutableMapOf<SurveyItem, List<String>>()
+
+        newItems.forEachIndexed { index, item ->
+            item.options?.let {
+                if (it.isNotEmpty()) {
+                    itemOptionsMap[savedItems[index]] = it
+                }
+            }
+        }
+
+        val allOptions =
+            itemOptionsMap.flatMap { (item, options) ->
+                options.map { optionValue ->
+                    ItemOption(
+                        surveyItemId = item.id,
+                        value = optionValue,
+                    )
+                }
+            }
+
+        if (allOptions.isNotEmpty()) {
+            itemOptionRepository.saveAll(allOptions)
+        }
+    }
+
+    fun updateSurveyItems(surveyItems: List<SurveyItem>) {
+        val itemDataMap = surveyItems.associateBy { it.id }
+
+        val itemIds = surveyItems.map { it.id }
+
+        val existingItems = surveyItemRepository.findAllById(itemIds)
+
+        existingItems.forEach { item ->
+            val itemData = itemDataMap[item.id] ?: return@forEach
+
+            item.update(
+                title = itemData.title,
+                description = itemData.description,
+                inputType = itemData.inputType,
+                isRequired = itemData.isRequired,
+            )
+        }
+
+        surveyItemRepository.updateItems(existingItems)
     }
 }

--- a/project/sangkyeong-onboarding/domain/src/main/kotlin/org/survey/domain/survey/service/SurveyQueryService.kt
+++ b/project/sangkyeong-onboarding/domain/src/main/kotlin/org/survey/domain/survey/service/SurveyQueryService.kt
@@ -24,6 +24,11 @@ class SurveyQueryService(
     }
 
     fun getItemOptions(surveyItemIds: List<Long>): List<ItemOption> {
-        return itemOptionRepository.findBySurveyItemIdIn(surveyItemIds)
+        return itemOptionRepository.findBySurveyItemsIdIn(surveyItemIds)
+    }
+
+    fun getItemOptionsGroupBySurveyItem(itemIds: List<Long>): Map<Long, List<ItemOption>> {
+        val options = itemOptionRepository.findBySurveyItemsIdIn(itemIds)
+        return options.groupBy { it.surveyItemId }
     }
 }

--- a/project/sangkyeong-onboarding/domain/src/test/kotlin/org/survey/domain/service/CreateSurveyDomainServiceTest.kt
+++ b/project/sangkyeong-onboarding/domain/src/test/kotlin/org/survey/domain/service/CreateSurveyDomainServiceTest.kt
@@ -33,7 +33,7 @@ class CreateSurveyDomainServiceTest : BehaviorSpec({
                     shouldThrow<IllegalArgumentException> {
                         surveyCommandService.createSurvey(title, description, emptyItems)
                     }
-                exception.message shouldBe "설문 항목이 최소 1개 이상 필요하다."
+                exception.message shouldBe "설문 항목이 최소 1개 이상 필요합니다."
             }
         }
 
@@ -54,7 +54,7 @@ class CreateSurveyDomainServiceTest : BehaviorSpec({
                     shouldThrow<IllegalArgumentException> {
                         surveyCommandService.createSurvey(title, description, tooManyItems)
                     }
-                exception.message shouldBe "설문 항목은 최대 10개까지 가능하다."
+                exception.message shouldBe "설문 항목은 최대 10개까지 가능합니다."
             }
         }
 
@@ -142,7 +142,7 @@ class CreateSurveyDomainServiceTest : BehaviorSpec({
                     shouldThrow<IllegalArgumentException> {
                         surveyCommandService.createSurvey(title, description, invalidShortTextItem)
                     }
-                exception.message shouldBe "선택형 질문이 아니면 선택지가 없어야 한다."
+                exception.message shouldBe "선택형 질문이 아니면 선택지가 없어야 합니다."
             }
         }
 
@@ -163,7 +163,7 @@ class CreateSurveyDomainServiceTest : BehaviorSpec({
                     shouldThrow<IllegalArgumentException> {
                         surveyCommandService.createSurvey(title, description, invalidChoiceItem)
                     }
-                exception.message shouldBe "선택형 질문에는 최소 1개 이상의 선택지가 필요하다."
+                exception.message shouldBe "선택형 질문에는 최소 1개 이상의 선택지가 필요합니다."
             }
         }
     }

--- a/project/sangkyeong-onboarding/http/create-survey.http
+++ b/project/sangkyeong-onboarding/http/create-survey.http
@@ -33,7 +33,7 @@ Content-Type: application/json
 }
 
 ### 설문조사 조회
-GET http://localhost:8080/api/v1/surveys/4
+GET http://localhost:8080/api/v1/surveys/3
 Content-Type: application/json
 
 ### 설문조사 응답 생성

--- a/project/sangkyeong-onboarding/http/update-survey.http
+++ b/project/sangkyeong-onboarding/http/update-survey.http
@@ -1,0 +1,90 @@
+### 설문조사2 조회
+GET http://localhost:8080/api/v1/surveys/2
+Content-Type: application/json
+
+### 설문조사2 수정
+PATCH http://localhost:8080/api/v1/surveys/2
+Content-Type: application/json
+
+{
+  "title": "직원 복지 설문조사 수정",
+  "description": "더 나은 근무 환경을 위한 직원 의견 조사입니다. 수정",
+  "items": [
+    {
+      "id": 6,
+      "title": "부서수정",
+      "description": "수정 소속 부서를 선택해주세요.",
+      "inputType": "SINGLE_CHOICE",
+      "options": [],
+      "isRequired": true
+    },
+    {
+      "id": 9,
+      "title": "기타 추가 의견 수정",
+      "description": "아무 의견 내시오. 수정",
+      "inputType": "LONG_TEXT",
+      "options": [],
+      "isRequired": true
+    },
+    {
+      "id": 8,
+      "title": "회원 복지 제도 수정",
+      "description": "도입되었으면 하는 복지 제도를 모두 선택해주세요. 수정",
+      "inputType": "LONG_TEXT",
+      "options": [],
+      "isRequired": false
+    }
+  ]
+}
+
+### 설문조사2 수정 조회
+GET http://localhost:8080/api/v1/surveys/2
+Content-Type: application/json
+
+### 설문조사4 조회
+GET http://localhost:8080/api/v1/surveys/4
+Content-Type: application/json
+
+### 설문조사 수정4
+PATCH http://localhost:8080/api/v1/surveys/4
+Content-Type: application/json
+
+{
+  "title": "온보딩 설문조사 수정",
+  "description": "온보딩에 대한 의견을 남겨주세요. 수정",
+  "items": [
+    {
+      "id": 13,
+      "title": "온보딩 프로젝트의 난이도 설문조사 수정",
+      "description": "난이도는 1(매우 쉬움)부터 5(매우 어려움)까지의 점수로 평가해주세요. 수정",
+      "inputType": "MULTIPLE_CHOICE",
+      "isRequired": true,
+      "options": [
+        {
+          "id": 36,
+          "value": "6"
+        },
+        {
+          "id": 37,
+          "value": "7"
+        },
+        {
+          "id": 38,
+          "value": "8"
+        },
+        {
+          "id": 39,
+          "value": "9"
+        },
+        {
+          "id": 40,
+          "value": "10"
+        }
+      ]
+    }
+  ]
+}
+
+### 설문조사4 수정 조회
+GET http://localhost:8080/api/v1/surveys/4
+Content-Type: application/json

--- a/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/SurveyMapper.kt
+++ b/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/SurveyMapper.kt
@@ -39,6 +39,7 @@ fun SurveyItemEntity.toDomain() =
         description = this.description,
         inputType = this.inputType,
         isRequired = this.isRequired,
+        isDeleted = this.isDeleted,
     )
 
 fun ItemOption.toEntity() =

--- a/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/survey/ItemOptionEntity.kt
+++ b/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/survey/ItemOptionEntity.kt
@@ -21,4 +21,7 @@ class ItemOptionEntity(
 
     var value: String = value
         protected set
+
+    var isDeleted: Boolean = false
+        protected set
 }

--- a/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/survey/SurveyEntity.kt
+++ b/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/survey/SurveyEntity.kt
@@ -31,4 +31,13 @@ class SurveyEntity(
     @Column(nullable = false)
     var updatedAt: LocalDateTime = LocalDateTime.now()
         protected set
+
+    fun updateFromDomain(
+        newTitle: String,
+        newDescription: String,
+    ) {
+        this.title = newTitle
+        this.description = newDescription
+        this.updatedAt = LocalDateTime.now()
+    }
 }

--- a/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/survey/SurveyItemEntity.kt
+++ b/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/entity/survey/SurveyItemEntity.kt
@@ -36,4 +36,16 @@ class SurveyItemEntity(
 
     var isDeleted: Boolean = false
         protected set
+
+    fun update(
+        title: String,
+        description: String?,
+        inputType: String,
+        isRequired: Boolean,
+    ) {
+        this.title = title
+        this.description = description
+        this.inputType = inputType
+        this.isRequired = isRequired
+    }
 }

--- a/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/respository/survey/SurveyItemRepositoryImpl.kt
+++ b/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/respository/survey/SurveyItemRepositoryImpl.kt
@@ -1,6 +1,8 @@
 package org.survey.infra.persistence.respository.survey
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import org.survey.domain.survey.model.SurveyItem
 import org.survey.domain.survey.repository.SurveyItemRepository
@@ -10,6 +12,10 @@ import org.survey.infra.persistence.toEntity
 
 interface SurveyItemJpaRepository : JpaRepository<SurveyItemEntity, Long> {
     fun findBySurveyIdAndIsDeletedIsFalse(surveyId: Long): List<SurveyItemEntity>
+
+    @Modifying
+    @Query("UPDATE SurveyItemEntity s SET s.isDeleted = true WHERE s.id IN :ids")
+    fun markItemsAsDeletedById(ids: List<Long>): Int
 }
 
 @Repository
@@ -26,5 +32,28 @@ class SurveyItemRepositoryImpl(
 
     override fun findBySurveyId(surveyId: Long): List<SurveyItem> {
         return surveyItemJpaRepository.findBySurveyIdAndIsDeletedIsFalse(surveyId).map { it.toDomain() }
+    }
+
+    override fun findAllById(surveyItemIds: List<Long>): List<SurveyItem> {
+        return surveyItemJpaRepository.findAllById(surveyItemIds).map { it.toDomain() }
+    }
+
+    override fun deleteItems(surveyItems: List<SurveyItem>) {
+        surveyItemJpaRepository.markItemsAsDeletedById(surveyItems.map { it.id })
+    }
+
+    override fun updateItems(surveyItems: List<SurveyItem>) {
+        val map = surveyItems.associateBy { it.id }
+        val surveyItemEntities = surveyItemJpaRepository.findAllById(map.keys).associateBy { it.id }
+        surveyItemEntities.forEach { (id, entity) ->
+            val surveyItem = map[id] ?: return@forEach
+            entity.update(
+                title = surveyItem.title,
+                description = surveyItem.description,
+                inputType = surveyItem.inputType,
+                isRequired = surveyItem.isRequired,
+            )
+        }
+        surveyItemJpaRepository.saveAll(surveyItemEntities.values)
     }
 }

--- a/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/respository/survey/SurveyRepositoryImpl.kt
+++ b/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/respository/survey/SurveyRepositoryImpl.kt
@@ -15,17 +15,12 @@ interface SurveyJpaRepository : JpaRepository<SurveyEntity, Long>
 class SurveyRepositoryImpl(
     private val surveyJpaRepository: SurveyJpaRepository,
 ) : SurveyRepository {
-//    override fun save(survey: Survey): Long {
-//
-//        return surveyJpaRepository.save(survey.toNewEntity()).id
-//    }
-
     override fun save(survey: Survey): Long {
         val entityToSave =
             if (survey.id > 0) {
                 val existingEntity =
                     surveyJpaRepository.findByIdOrNull(survey.id)
-                        ?: throw IllegalArgumentException("업데이트할 설문조사가 없습니다: ${survey.id}")
+                        ?: throw IllegalArgumentException("업데이트할 설문조사가 없습니다")
 
                 existingEntity.updateFromDomain(survey.title, survey.description)
                 existingEntity

--- a/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/respository/survey/SurveyRepositoryImpl.kt
+++ b/project/sangkyeong-onboarding/infra/src/main/kotlin/org/survey/infra/persistence/respository/survey/SurveyRepositoryImpl.kt
@@ -15,8 +15,24 @@ interface SurveyJpaRepository : JpaRepository<SurveyEntity, Long>
 class SurveyRepositoryImpl(
     private val surveyJpaRepository: SurveyJpaRepository,
 ) : SurveyRepository {
+//    override fun save(survey: Survey): Long {
+//
+//        return surveyJpaRepository.save(survey.toNewEntity()).id
+//    }
+
     override fun save(survey: Survey): Long {
-        return surveyJpaRepository.save(survey.toEntity()).id
+        val entityToSave =
+            if (survey.id > 0) {
+                val existingEntity =
+                    surveyJpaRepository.findByIdOrNull(survey.id)
+                        ?: throw IllegalArgumentException("업데이트할 설문조사가 없습니다: ${survey.id}")
+
+                existingEntity.updateFromDomain(survey.title, survey.description)
+                existingEntity
+            } else {
+                survey.toEntity()
+            }
+        return surveyJpaRepository.save(entityToSave).id
     }
 
     override fun findById(id: Long): Survey? {

--- a/project/sangkyeong-onboarding/presentation/src/main/kotlin/org/survey/presentation/api/SurveyManagementController.kt
+++ b/project/sangkyeong-onboarding/presentation/src/main/kotlin/org/survey/presentation/api/SurveyManagementController.kt
@@ -1,6 +1,7 @@
 package org.survey.presentation.api
 
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -9,7 +10,9 @@ import org.springframework.web.bind.annotation.RestController
 import org.survey.application.dto.response.SurveyResponse
 import org.survey.application.usecase.survey.CreateSurveyUseCase
 import org.survey.application.usecase.survey.GetSurveyUseCase
+import org.survey.application.usecase.survey.UpdateSurveyUseCase
 import org.survey.presentation.dto.request.CreateSurveyRequest
+import org.survey.presentation.dto.request.UpdateSurveyRequest
 import org.survey.presentation.dto.request.toCommand
 
 @RestController
@@ -17,6 +20,7 @@ import org.survey.presentation.dto.request.toCommand
 class SurveyManagementController(
     private val createSurveyUseCase: CreateSurveyUseCase,
     private val getSurveyUseCase: GetSurveyUseCase,
+    private val updateSurveyUseCase: UpdateSurveyUseCase,
 ) {
     @PostMapping
     fun createSurvey(
@@ -31,5 +35,14 @@ class SurveyManagementController(
         @PathVariable("surveyId") surveyId: Long,
     ): SurveyResponse {
         return getSurveyUseCase.execute(surveyId)
+    }
+
+    @PatchMapping("/{surveyId}")
+    fun updateSurvey(
+        @PathVariable("surveyId") surveyId: Long,
+        @RequestBody request: UpdateSurveyRequest,
+    ) {
+        val updateSurveyCommand = request.toCommand()
+        updateSurveyUseCase.execute(surveyId, updateSurveyCommand)
     }
 }

--- a/project/sangkyeong-onboarding/presentation/src/main/kotlin/org/survey/presentation/dto/request/UpdateSurveyRequest.kt
+++ b/project/sangkyeong-onboarding/presentation/src/main/kotlin/org/survey/presentation/dto/request/UpdateSurveyRequest.kt
@@ -1,0 +1,55 @@
+package org.survey.presentation.dto.request
+
+import org.survey.application.dto.command.UpdateItemOptionCommand
+import org.survey.application.dto.command.UpdateSurveyCommand
+import org.survey.application.dto.command.UpdateSurveyItemCommand
+
+data class UpdateSurveyRequest(
+    val title: String,
+    val description: String,
+    val items: List<UpdateSurveyItemRequest>,
+)
+
+data class UpdateSurveyItemRequest(
+    val id: Long,
+    val title: String,
+    val description: String,
+    val inputType: String,
+    val isRequired: Boolean,
+    val options: List<UpdateItemOptionRequest>? = null,
+) {
+    init {
+        require(
+            inputType.contentEquals("SHORT_TEXT") ||
+                inputType.contentEquals("LONG_TEXT") ||
+                inputType.contentEquals("SINGLE_CHOICE") ||
+                inputType.contentEquals("MULTIPLE_CHOICE"),
+        ) {
+            "inputType은 SHORT_TEXT, LONG_TEXT, SINGLE_CHOICE, MULTIPLE_CHOICE 중 하나여야 합니다."
+        }
+    }
+}
+
+data class UpdateItemOptionRequest(
+    val id: Long,
+    val value: String,
+)
+
+fun UpdateSurveyRequest.toCommand() =
+    UpdateSurveyCommand(
+        title = title,
+        description = description,
+        items = items.map { it.toCommand() },
+    )
+
+private fun UpdateSurveyItemRequest.toCommand() =
+    UpdateSurveyItemCommand(
+        id = id,
+        title = title,
+        description = description,
+        inputType = inputType,
+        isRequired = isRequired,
+        options = options?.map { it.toCommand() },
+    )
+
+private fun UpdateItemOptionRequest.toCommand() = UpdateItemOptionCommand(id = id, value = value)


### PR DESCRIPTION
## Goal

<!-- Describe the goal of this PR -->
설문조사 수정 API를 추가합니다.

## Description

<!-- Describe the changes made in this PR -->
ItemOption에 대한 업데이트는 아직 구현이 덜 된 상태라 제외하고 일단 작업된 부분까지 올립니다.

아래와 같은 과정으로 진행되도록 작업했습니다.
1. 설문조사 제목, 설명 업데이트
2. 기존 항목과 요청 항목 비교
3. 요청에 없는 기존 항목은 논리적 삭제
4. 새 항목 추가
5. 기존 항목 업데이트
6. 선택형 항목의 사용하지 않는 옵션 논리적 삭제 TODO
7. 선택형 항목 의 새 옵션 추가 TODO
8. 선택형 항목 의 기존 옵션 업데이트 TODO

## Question
도메인과 엔티티가 분리된 상태에서의 과정에 대한 궁금증이 있습니다.
예를 들어, 레이어드 아키텍처에서는 Entity를 불러와서 해당 Entity내에 update 로직을 호출하고 더티체킹으로 업데이트 진행시키는게 일반적인 거 같은데, 도메인과 엔티티가 분리되어 있을 때 도메인 비즈니스 로직을 최대한 사용하려고 했는데 고민되는 상황이 있습니다.

### 설문조사 업데이트 진행 시
레이어드인 경우 조회 후 변경이라는 간단한 과정이라고 보면, 도메인과 인프라가 분리되어 있을 때는 추가로 도메인 <-> 엔티티 변환과정이 추가되고 도메인 비즈니스 로직을 사용하기 위해 아래처럼 인프라에서 굳이 또 엔티티를 불러오는 추가적인 로직들이 발생을 하는데요. 그렇다고 도메인 레이어에서 비즈니스 로직을 사용하지 않고 surveyRepository로 바로 파라미터 넘겨버리면 DDD가 아니게 되는 느낌이기도 하구요. 보통 어떻게 진행하시나요?
```
fun updateSurvey(
        surveyId: Long,
        title: String,
        description: String,
    ) {
        val survey =
            surveyRepository.findById(surveyId)
                ?: throw IllegalArgumentException("설문조사를 찾을 수 없습니다.")

        survey.update(title, description)

        surveyRepository.save(survey)
    }

override fun save(survey: Survey): Long {
        return surveyJpaRepository.save(survey.toEntity()).id
        val entityToSave =
            if (survey.id > 0) {
                val existingEntity =
                    surveyJpaRepository.findByIdOrNull(survey.id)
                        ?: throw IllegalArgumentException("업데이트할 설문조사가 없습니다")

                existingEntity.updateFromDomain(survey.title, survey.description)
                existingEntity
            } else {
                survey.toEntity()
            }
        return surveyJpaRepository.save(entityToSave).id
    }
```