### PR TITLE
설문조사 응답 api 기능 구현

### DIFF
--- a/project/seonghun-onboarding/README.md
+++ b/project/seonghun-onboarding/README.md
@@ -78,7 +78,53 @@ item : {
 </details>
 
 ### 설문조사 응답
+<details>
+<summary>설문조사 응답 제출 api</summary>
+<div markdown="1">
 
+| Http Method | Path            |
+|------------|-----------------|
+| POST       | /answers/submit |
+
+- Request
+
+| Param     | Type         | Description |
+|-----------|--------------|------------|
+| name      | String       | 응답자        |
+| items     | json         | 질문 항목      |
+| responses | List<String> | 응답 항목      |
+
+> items json 형식
+```
+{
+  "question" : String,
+  "contents" : List<String>
+}
+```
+
+
+- Response
+
+```
+{
+    "status": 200,
+    "result": 
+        {
+            "id": Long,
+            "name": String,
+            "items": {
+                          "question" : String,
+                          "contents" : List<String>
+                        },
+            "responses": List<String>
+        }
+}
+
+```
+
+
+</div>
+</details>
 
 ## 상세 기능
 

--- a/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/common/JsonConverter.kt
+++ b/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/common/JsonConverter.kt
@@ -1,0 +1,61 @@
+package com.chosseang.seonghunonboarding.common
+
+import com.chosseang.seonghunonboarding.dto.QuestionItem
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.stereotype.Component
+
+@Component
+class JsonConverter {
+
+    private val objectMapper = ObjectMapper()
+
+    /**
+     * 질문 항목 맵을 JSON 문자열로 변환
+     */
+    fun convertItemsToJson(items: Map<String, QuestionItem>): String {
+        try {
+            return objectMapper.writeValueAsString(items)
+        } catch (e: JsonProcessingException) {
+            throw IllegalArgumentException("Error converting items to JSON", e)
+        }
+    }
+
+    /**
+     * JSON 문자열을 질문 항목 맵으로 변환
+     */
+    fun convertJsonToItems(json: String): Map<String, QuestionItem> {
+        if (json.isBlank()) return emptyMap()
+
+        try {
+            return objectMapper.readValue(json, object : TypeReference<Map<String, QuestionItem>>() {})
+        } catch (e: JsonProcessingException) {
+            throw IllegalArgumentException("Error converting JSON to items", e)
+        }
+    }
+
+    /**
+     * 응답 맵을 JSON 문자열로 변환
+     */
+    fun convertResponsesToJson(responses: Map<String, List<String>>): String {
+        try {
+            return objectMapper.writeValueAsString(responses)
+        } catch (e: JsonProcessingException) {
+            throw IllegalArgumentException("Error converting responses to JSON", e)
+        }
+    }
+
+    /**
+     * JSON 문자열을 응답 맵으로 변환
+     */
+    fun convertJsonToResponses(json: String): Map<String, List<String>> {
+        if (json.isBlank()) return emptyMap()
+
+        try {
+            return objectMapper.readValue(json, object : TypeReference<Map<String, List<String>>>() {})
+        } catch (e: JsonProcessingException) {
+            throw IllegalArgumentException("Error converting JSON to responses", e)
+        }
+    }
+}

--- a/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/controller/AnswerController.kt
+++ b/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/controller/AnswerController.kt
@@ -1,0 +1,31 @@
+package com.chosseang.seonghunonboarding.controller
+
+import com.chosseang.seonghunonboarding.dto.AnswerResponse
+import com.chosseang.seonghunonboarding.dto.AnswerSubmitRequest
+import com.chosseang.seonghunonboarding.dto.ApiResponse
+import com.chosseang.seonghunonboarding.service.AnswerService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/answer")
+class AnswerController(private val answerService: AnswerService) {
+
+    @PostMapping("/submit")
+    @ResponseBody
+    fun submitAnswer(@RequestBody request: AnswerSubmitRequest): ResponseEntity<ApiResponse<AnswerResponse>> {
+        val result = answerService.submitAnswer(request)
+
+        val apiResponse = ApiResponse(
+            status = HttpStatus.OK.value(),
+            result = result
+        )
+
+        return ResponseEntity.ok(apiResponse)
+    }
+}

--- a/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/dto/AnswerProtocols.kt
+++ b/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/dto/AnswerProtocols.kt
@@ -1,0 +1,25 @@
+package com.chosseang.seonghunonboarding.dto
+
+import com.chosseang.seonghunonboarding.entity.Answer
+import com.chosseang.seonghunonboarding.enum.ItemType
+
+data class AnswerSubmitRequest(
+    val name: String,
+    val items: Map<String, QuestionItem>,  // 질문 ID를 키로, QuestionItem을 값으로 하는 맵
+    val responses: Map<String, List<String>>,  // 질문 ID를 키로, 응답을 값으로 하는 맵
+    val surveyId: Long
+)
+
+data class AnswerResponse(
+    val id: Long?,
+    val name: String,
+    val items: Map<String, QuestionItem>,
+    val responses: Map<String, List<String>>
+)
+
+data class QuestionItem(
+    val text: String,                  // 질문 텍스트
+    val type: ItemType,                // 질문 유형 (ShortAnswer, LongAnswer, SingleSelect, MultiSelect)
+    val options: List<String>,         // 선택 옵션 목록
+    val required: Boolean = false      // 필수 응답 여부
+)

--- a/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/entity/Answer.kt
+++ b/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/entity/Answer.kt
@@ -1,6 +1,7 @@
 package com.chosseang.seonghunonboarding.entity
 
 import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
 import jakarta.persistence.ElementCollection
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
@@ -13,17 +14,15 @@ import jakarta.persistence.ManyToOne
 data class Answer(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long,
+    val id: Long?,
 
     val name: String,
 
-    @ElementCollection
-    @CollectionTable(name = "answer_items", joinColumns = [JoinColumn(name = "answer_id")])
-    val items: List<String>,
+    @Column(columnDefinition = "TEXT")
+    val items: String,
 
-    @ElementCollection
-    @CollectionTable(name = "answer_responses", joinColumns = [JoinColumn(name = "answer_id")])
-    val responses: List<String>,
+    @Column(columnDefinition = "TEXT")
+    val responses: String,
 
     @ManyToOne
     @JoinColumn(name = "survey_id")

--- a/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/repository/AnswerRepository.kt
+++ b/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/repository/AnswerRepository.kt
@@ -1,0 +1,9 @@
+package com.chosseang.seonghunonboarding.repository
+
+import com.chosseang.seonghunonboarding.entity.Answer
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface AnswerRepository : JpaRepository<Answer, Long> {
+}

--- a/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/service/AnswerService.kt
+++ b/project/seonghun-onboarding/src/main/kotlin/com/chosseang/seonghunonboarding/service/AnswerService.kt
@@ -1,0 +1,47 @@
+package com.chosseang.seonghunonboarding.service
+
+import com.chosseang.seonghunonboarding.common.JsonConverter
+import com.chosseang.seonghunonboarding.dto.AnswerResponse
+import com.chosseang.seonghunonboarding.dto.AnswerSubmitRequest
+import com.chosseang.seonghunonboarding.entity.Answer
+import com.chosseang.seonghunonboarding.repository.AnswerRepository
+import com.chosseang.seonghunonboarding.repository.SurveyRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class AnswerService (
+    private val answerRepository: AnswerRepository,
+    private val surveyRepository: SurveyRepository,
+    private val jsonConverter: JsonConverter
+){
+    fun submitAnswer(request: AnswerSubmitRequest): AnswerResponse {
+        // 설문조사 찾기
+        val survey = surveyRepository.findByIdOrNull(request.surveyId)
+            ?: throw IllegalArgumentException("Survey not found with id: ${request.surveyId}")
+
+        val itemsJson = jsonConverter.convertItemsToJson(request.items)
+        val responsesJson = jsonConverter.convertResponsesToJson(request.responses)
+
+        // Answer 엔티티 생성
+        val answer = Answer(
+            id = null,  // 새로운 응답이므로 id는 null로 설정
+            name = request.name,
+            items = itemsJson,
+            responses = responsesJson,
+            survey = survey
+        )
+
+        // 저장 및 응답 변환
+        val savedAnswer = answerRepository.save(answer)
+
+        return AnswerResponse(
+            id = savedAnswer.id,
+            name = savedAnswer.name,
+            items = request.items,  // 원본 데이터 사용
+            responses = request.responses
+        )
+    }
+}


### PR DESCRIPTION
## Goal

설문조사 응답 기능 구현

## Changes

- 도메인 추가
  - AnswerService
  - AnswerController
- repository 추가
  - AnswerRepository
- Entity 수정
  - Answer 
- DTO 추가
  - AnswerProtocols 
- api 상세 명세서 작성
  - README
- 기타 유틸용 코드
  - JsonConverter

## Description

설문조사 응답 제출 api 기능을 구현하였습니다.
기존에 설계했던 내용과 다르게 질문과 응답의 경우 json 형태로 DB에 넣었습니다.
