### PR TITLE
feat: 설문 생성 API 구현

### DIFF
--- a/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/api/survey/SurveyController.kt
+++ b/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/api/survey/SurveyController.kt
@@ -1,0 +1,24 @@
+package com.innercircle.presurveyapi.api.survey
+
+import com.innercircle.presurveyapi.api.survey.dto.CreateSurveyRequest
+import com.innercircle.presurveyapi.api.survey.dto.SurveyResponse
+import com.innercircle.presurveyapi.application.survey.command.CreateSurveyUseCase
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/surveys")
+class SurveyController(
+    private val createSurveyUseCase: CreateSurveyUseCase
+) {
+
+    @PostMapping
+    fun createSurvey(@RequestBody request: CreateSurveyRequest): ResponseEntity<SurveyResponse> {
+        val command = request.toCommand()
+        val survey = createSurveyUseCase.invoke(command)
+        return ResponseEntity.ok(SurveyResponse.from(survey))
+    }
+}

--- a/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/api/survey/dto/CreateSurveyRequest.kt
+++ b/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/api/survey/dto/CreateSurveyRequest.kt
@@ -1,0 +1,33 @@
+package com.innercircle.presurveyapi.api.survey.dto
+
+import com.innercircle.presurveyapi.application.survey.command.CreateQuestionCommand
+import com.innercircle.presurveyapi.application.survey.command.CreateSurveyCommand
+import com.innercircle.presurveyapi.domain.survey.model.QuestionType
+
+data class CreateSurveyRequest(
+    val title: String, // 설문조사 이름
+    val description: String, //설문조사 설명
+    val questions: List<CreateQuestionRequest> //설문 받을 항목
+) {
+    fun toCommand(): CreateSurveyCommand = CreateSurveyCommand(
+        title = title,
+        description = description,
+        questions = questions.map { it.toCommand() }
+    )
+}
+
+data class CreateQuestionRequest(
+    val title: String, //항목 이름
+    val description: String, //항목 설명
+    val type: QuestionType, //항목 이름 형태
+    val required: Boolean, //항목 필수 여부
+    val options: List<String> = emptyList()
+) {
+    fun toCommand(): CreateQuestionCommand = CreateQuestionCommand(
+        title = title,
+        description = description,
+        type = type,
+        required = required,
+        options = options
+    )
+}

--- a/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/api/survey/dto/SurveyResponse.kt
+++ b/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/api/survey/dto/SurveyResponse.kt
@@ -1,0 +1,61 @@
+package com.innercircle.presurveyapi.api.survey.dto
+
+import com.innercircle.presurveyapi.domain.survey.model.Question
+import com.innercircle.presurveyapi.domain.survey.model.QuestionOption
+import com.innercircle.presurveyapi.domain.survey.model.QuestionType
+import com.innercircle.presurveyapi.domain.survey.model.Survey
+import java.util.*
+
+data class SurveyResponse(
+    val id: UUID?,
+    val title: String,
+    val description: String,
+    val questions: List<QuestionResponse>
+) {
+    companion object {
+        fun from(survey: Survey): SurveyResponse {
+            return SurveyResponse(
+                id = survey.id,
+                title = survey.title,
+                description = survey.description,
+                questions = survey.questions.map { QuestionResponse.from(it) }
+            )
+        }
+    }
+}
+
+data class QuestionResponse(
+    val id: UUID?,
+    val title: String,
+    val description: String,
+    val type: QuestionType,
+    val required: Boolean,
+    val options: List<OptionResponse> = emptyList()
+) {
+    companion object {
+        fun from(question: Question): QuestionResponse {
+            return QuestionResponse(
+                id = null,
+                title = question.title,
+                description = question.description,
+                type = question.type,
+                required = question.required,
+                options = question.options.map { OptionResponse.from(it) }
+            )
+        }
+    }
+}
+
+data class OptionResponse(
+    val id: UUID,
+    val text: String
+) {
+    companion object {
+        fun from(option: QuestionOption): OptionResponse {
+            return OptionResponse(
+                id = option.id,
+                text = option.text
+            )
+        }
+    }
+}

--- a/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/application/survey/command/CreateSurveyCommand.kt
+++ b/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/application/survey/command/CreateSurveyCommand.kt
@@ -1,0 +1,17 @@
+package com.innercircle.presurveyapi.application.survey.command
+
+import com.innercircle.presurveyapi.domain.survey.model.QuestionType
+
+data class CreateSurveyCommand(
+    val title: String,
+    val description: String,
+    val questions: List<CreateQuestionCommand>
+)
+
+data class CreateQuestionCommand(
+    val title: String,
+    val description: String,
+    val type: QuestionType,
+    val required: Boolean,
+    val options: List<String> = emptyList()
+)

--- a/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/application/survey/command/CreateSurveyUseCase.kt
+++ b/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/application/survey/command/CreateSurveyUseCase.kt
@@ -1,0 +1,13 @@
+package com.innercircle.presurveyapi.application.survey.command
+
+import com.innercircle.presurveyapi.domain.survey.model.Survey
+import com.innercircle.presurveyapi.domain.survey.repository.SurveyRepository
+
+class CreateSurveyUseCase(
+    private val surveyRepository: SurveyRepository
+) {
+    fun invoke(command: CreateSurveyCommand): Survey {
+        val survey = Survey.create(command)
+        return surveyRepository.save(survey)
+    }
+}

--- a/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/common/logging/MdcFilter.kt
+++ b/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/common/logging/MdcFilter.kt
@@ -1,4 +1,4 @@
-package com.innercircle.presurveyapi.common
+package com.innercircle.presurveyapi.common.logging
 
 import jakarta.servlet.Filter
 import jakarta.servlet.FilterChain

--- a/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/common/logging/logger.kt
+++ b/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/common/logging/logger.kt
@@ -1,4 +1,4 @@
-package com.innercircle.presurveyapi.common
+package com.innercircle.presurveyapi.common.logging
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory

--- a/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/config/AppConfig.kt
+++ b/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/config/AppConfig.kt
@@ -1,7 +1,7 @@
 package com.innercircle.presurveyapi.config
 
 
-import com.innercircle.presurveyapi.common.MdcFilter
+import com.innercircle.presurveyapi.common.logging.MdcFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.boot.web.servlet.FilterRegistrationBean

--- a/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/config/PersistenceAdapterConfig.kt
+++ b/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/config/PersistenceAdapterConfig.kt
@@ -1,0 +1,19 @@
+package com.innercircle.presurveyapi.config
+
+import com.innercircle.presurveyapi.domain.survey.repository.SurveyRepository
+import com.innercircle.presurveyapi.infrastructure.adapter.survey.SurveyMapper
+import com.innercircle.presurveyapi.infrastructure.adapter.survey.SurveyPersistenceAdapter
+import com.innercircle.presurveyapi.infrastructure.persistence.survey.SurveyJpaRepository
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class PersistenceAdapterConfig {
+    @Bean
+    fun surveyRepository(
+        surveyJpaRepository: SurveyJpaRepository,
+        surveyMapper: SurveyMapper
+    ): SurveyRepository {
+        return SurveyPersistenceAdapter(surveyJpaRepository, surveyMapper)
+    }
+}

--- a/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/config/UseCaseConfig.kt
+++ b/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/config/UseCaseConfig.kt
@@ -1,0 +1,17 @@
+package com.innercircle.presurveyapi.config
+
+import com.innercircle.presurveyapi.application.survey.command.CreateSurveyUseCase
+import com.innercircle.presurveyapi.domain.survey.repository.SurveyRepository
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class UseCaseConfig {
+
+    @Bean
+    fun createSurveyUseCase(
+        surveyRepository: SurveyRepository
+    ): CreateSurveyUseCase {
+        return CreateSurveyUseCase(surveyRepository)
+    }
+}

--- a/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/domain/survey/model/Question.kt
+++ b/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/domain/survey/model/Question.kt
@@ -1,0 +1,32 @@
+package com.innercircle.presurveyapi.domain.survey.model
+
+import com.innercircle.presurveyapi.application.survey.command.CreateQuestionCommand
+import java.util.*
+
+data class Question(
+    val id: UUID?,
+    val title: String,
+    val description: String,
+    val type: QuestionType,
+    val required: Boolean,
+    val options: List<QuestionOption> = emptyList()
+) {
+    companion object {
+        fun create(command: CreateQuestionCommand): Question {
+            if (command.type.isChoice()) {
+                require(command.options.isNotEmpty()) {
+                    "선택형 질문에는 옵션이 필요합니다."
+                }
+            }
+
+            return Question(
+                id = UUID.randomUUID(),
+                title = command.title,
+                description = command.description,
+                type = command.type,
+                required = command.required,
+                options = command.options.map { QuestionOption(UUID.randomUUID(), it) }
+            )
+        }
+    }
+}

--- a/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/domain/survey/model/QuestionOption.kt
+++ b/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/domain/survey/model/QuestionOption.kt
@@ -1,0 +1,14 @@
+package com.innercircle.presurveyapi.domain.survey.model
+
+import java.util.*
+
+data class QuestionOption(
+    val id: UUID,
+    val text: String
+)
+
+enum class QuestionType {
+    SHORT_TEXT, LONG_TEXT, SINGLE_CHOICE, MULTIPLE_CHOICE;
+
+    fun isChoice(): Boolean = this == SINGLE_CHOICE || this == MULTIPLE_CHOICE
+}

--- a/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/domain/survey/model/Survey.kt
+++ b/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/domain/survey/model/Survey.kt
@@ -1,0 +1,26 @@
+package com.innercircle.presurveyapi.domain.survey.model
+
+import com.innercircle.presurveyapi.application.survey.command.CreateSurveyCommand
+import java.util.*
+
+data class Survey(
+    val id: UUID? = null,
+    val title: String,
+    val description: String,
+    val questions: List<Question>
+) {
+    companion object {
+        fun create(command: CreateSurveyCommand): Survey {
+            require(command.questions.size in 1..10) {
+                "질문은 1개 이상 10개 이하여야 합니다."
+            }
+
+            return Survey(
+                id = UUID.randomUUID(),
+                title = command.title,
+                description = command.description,
+                questions = command.questions.map { Question.create(it) }
+            )
+        }
+    }
+}

--- a/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/domain/survey/repository/SurveyRepository.kt
+++ b/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/domain/survey/repository/SurveyRepository.kt
@@ -1,0 +1,7 @@
+package com.innercircle.presurveyapi.domain.survey.repository
+
+import com.innercircle.presurveyapi.domain.survey.model.Survey
+
+interface SurveyRepository {
+    fun save(survey: Survey): Survey
+}

--- a/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/infrastructure/adapter/survey/SurveyMapper.kt
+++ b/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/infrastructure/adapter/survey/SurveyMapper.kt
@@ -1,0 +1,66 @@
+package com.innercircle.presurveyapi.infrastructure.adapter.survey
+
+import com.innercircle.presurveyapi.domain.survey.model.Question
+import com.innercircle.presurveyapi.domain.survey.model.QuestionOption
+import com.innercircle.presurveyapi.domain.survey.model.QuestionType
+import com.innercircle.presurveyapi.domain.survey.model.Survey
+import com.innercircle.presurveyapi.infrastructure.persistence.survey.QuestionJpaEntity
+import com.innercircle.presurveyapi.infrastructure.persistence.survey.QuestionOptionJpaEntity
+import com.innercircle.presurveyapi.infrastructure.persistence.survey.SurveyJpaEntity
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class SurveyMapper {
+
+    fun toEntity(domain: Survey): SurveyJpaEntity {
+        val survey = SurveyJpaEntity(
+            id = null,
+            title = domain.title,
+            description = domain.description,
+            questions = mutableListOf()
+        )
+
+        val questions = domain.questions.map { question ->
+            val options = question.options.map { option ->
+                QuestionOptionJpaEntity(
+                    id = null,
+                    text = option.text
+                )
+            }.toMutableList()
+
+            QuestionJpaEntity(
+                id = null,
+                survey = survey,
+                title = question.title,
+                description = question.description,
+                type = question.type.name,
+                required = question.required,
+                options = options
+            )
+        }
+
+        survey.questions.addAll(questions)
+        return survey
+    }
+
+    fun toDomain(entity: SurveyJpaEntity): Survey {
+        return Survey(
+            id = null,
+            title = entity.title,
+            description = entity.description,
+            questions = entity.questions.map { question: QuestionJpaEntity ->
+                Question(
+                    id = null,
+                    title = question.title,
+                    description = question.description,
+                    type = QuestionType.valueOf(question.type),
+                    required = question.required,
+                    options = question.options.map { option ->
+                        QuestionOption(id = option.id ?: UUID.randomUUID(), text = option.text)
+                    }
+                )
+            }
+        )
+    }
+}

--- a/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/infrastructure/adapter/survey/SurveyPersistenceAdapter.kt
+++ b/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/infrastructure/adapter/survey/SurveyPersistenceAdapter.kt
@@ -1,0 +1,17 @@
+package com.innercircle.presurveyapi.infrastructure.adapter.survey
+
+import com.innercircle.presurveyapi.domain.survey.model.Survey
+import com.innercircle.presurveyapi.domain.survey.repository.SurveyRepository
+import com.innercircle.presurveyapi.infrastructure.persistence.survey.SurveyJpaRepository
+
+class SurveyPersistenceAdapter(
+    private val surveyJpaRepository: SurveyJpaRepository,
+    private val surveyMapper: SurveyMapper
+) : SurveyRepository {
+
+    override fun save(survey: Survey): Survey {
+        val entity = surveyMapper.toEntity(survey)
+        val saved = surveyJpaRepository.save(entity)
+        return surveyMapper.toDomain(saved)
+    }
+}

--- a/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/infrastructure/persistence/survey/QuestionJpaEntity.kt
+++ b/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/infrastructure/persistence/survey/QuestionJpaEntity.kt
@@ -1,0 +1,40 @@
+package com.innercircle.presurveyapi.infrastructure.persistence.survey
+
+import jakarta.persistence.*
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+import java.util.*
+
+@Entity
+@Table(name = "question")
+class QuestionJpaEntity(
+
+    @Id
+    @GeneratedValue
+    val id: UUID? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "survey_id")
+    var survey: SurveyJpaEntity? = null,
+
+    val title: String,
+
+    val description: String,
+
+    val type: String, // Enum을 문자열로 저장 (QuestionType.name)
+
+    val required: Boolean,
+
+    @OneToMany(
+        cascade = [CascadeType.ALL],
+        orphanRemoval = true,
+        fetch = FetchType.LAZY
+    )
+    @JoinColumn(name = "question_id")
+    val options: List<QuestionOptionJpaEntity> = emptyList()
+) {
+
+    @CreationTimestamp
+    @Column(name = "create_date", updatable = false)
+    lateinit var createDate: LocalDateTime
+}

--- a/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/infrastructure/persistence/survey/QuestionOptionJpaEntity.kt
+++ b/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/infrastructure/persistence/survey/QuestionOptionJpaEntity.kt
@@ -1,0 +1,22 @@
+package com.innercircle.presurveyapi.infrastructure.persistence.survey
+
+import jakarta.persistence.*
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+import java.util.*
+
+@Entity
+@Table(name = "question_option")
+class QuestionOptionJpaEntity(
+
+    @Id
+    @GeneratedValue
+    val id: UUID? = null,
+
+    val text: String
+) {
+
+    @CreationTimestamp
+    @Column(name = "create_date", updatable = false)
+    lateinit var createDate: LocalDateTime
+}

--- a/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/infrastructure/persistence/survey/SurveyJpaEntity.kt
+++ b/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/infrastructure/persistence/survey/SurveyJpaEntity.kt
@@ -1,0 +1,33 @@
+package com.innercircle.presurveyapi.infrastructure.persistence.survey
+
+import jakarta.persistence.*
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+import java.util.*
+
+@Entity
+@Table(name = "survey")
+class SurveyJpaEntity(
+
+    @Id
+    @GeneratedValue
+    val id: UUID? = null,
+
+    val title: String,
+
+    val description: String,
+
+    @OneToMany(
+        mappedBy = "survey",
+        cascade = [CascadeType.ALL],
+        orphanRemoval = true,
+        fetch = FetchType.LAZY
+    )
+    var questions: MutableList<QuestionJpaEntity> = mutableListOf(),
+
+) {
+
+    @CreationTimestamp
+    @Column(name = "create_date", updatable = false)
+    lateinit var createDate: LocalDateTime
+}

--- a/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/infrastructure/persistence/survey/SurveyJpaRepository.kt
+++ b/project/hyunwoo-onboarding/presurvey-api/src/main/kotlin/com/innercircle/presurveyapi/infrastructure/persistence/survey/SurveyJpaRepository.kt
@@ -1,0 +1,6 @@
+package com.innercircle.presurveyapi.infrastructure.persistence.survey
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.*
+
+interface SurveyJpaRepository : JpaRepository<SurveyJpaEntity, UUID>

--- a/project/hyunwoo-onboarding/presurvey-api/src/test/kotlin/com/innercircle/presurveyapi/PresurveyApiApplicationTests.kt
+++ b/project/hyunwoo-onboarding/presurvey-api/src/test/kotlin/com/innercircle/presurveyapi/PresurveyApiApplicationTests.kt
@@ -1,6 +1,6 @@
 package com.innercircle.presurveyapi
 
-import com.innercircle.presurveyapi.common.logger
+import com.innercircle.presurveyapi.common.logging.logger
 import org.junit.jupiter.api.Test
 import org.slf4j.MDC
 import org.springframework.boot.test.context.SpringBootTest


### PR DESCRIPTION
## Goal

설문조사 생성 API를 구현하였습니다.

## Changes

기존에 없던 설문조사 생성 API를 구현후 commit & push 하였습니다.

## Description

 [설문조사 이름], [설문조사 설명], [설문 받을 항목]의 값을 받아 설문조사를 DB에 저장합니다.

## Additional Context (Optional)

<!-- Add any additional context or information here -->

## Screenshots/Videos (Optional)

<!-- Add screenshots if applicable -->

## References (Optional)

<!-- Add references like GitHub Issue, related PRs, etc. -->

